### PR TITLE
renamed spectral_resolution to spectral_bin_width

### DIFF
--- a/Armazones/Armazones.yaml
+++ b/Armazones/Armazones.yaml
@@ -3,6 +3,9 @@ object : atmosphere
 alias : ATMO
 name : armazones
 description : Atmosphere and location details for Cerro Armazones
+date-modified: 2022-01-12
+changes:
+  - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 properties :
     altitude :      3060        # m
@@ -32,8 +35,8 @@ effects :
         wmin : "!SIM.spectral.wave_min"
         wmax : "!SIM.spectral.wave_max"
         wunit : um
-        wdelta : "!SIM.spectral.spectral_resolution"
-
+        wres : "!SIM.spectral.spectral_resolution"
+        wdelta: "!SIM.spectral.spectral_bin_width"
 
 -   name : armazones_atmo_dispersion
     description : atmospheric dispersion

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -4,7 +4,9 @@ object: instrument
 alias: INST
 name: METIS_LSS
 description: additional effects for METIS long-slit spectroscopy
-
+date_modified: 2022-01-12
+changes:
+  - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 properties:
     decouple_detector_from_sky_headers: True
 
@@ -40,4 +42,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_resolution: !!float 5E-4   # microns (spectral bin width)
+    spectral_bin_width: !!float 5E-4   # microns (spectral bin width)
+    spectral_resolution: 5000

--- a/MICADO_ETC/MICADO_ETC.yaml
+++ b/MICADO_ETC/MICADO_ETC.yaml
@@ -2,7 +2,9 @@
 # description: effects for MICADO etc
 # author : Kieran Leschinski
 # date_created : 2020-11-02
-# date_modified : 2020-11-02
+# date_modified : 2022-01-12
+# changes:
+#   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 object : configuration
 alias : OBS
@@ -30,7 +32,7 @@ effects:
         wmin : "!SIM.spectral.wave_min"
         wmax : "!SIM.spectral.wave_max"
         wunit : um
-        wdelta : "!SIM.spectral.spectral_resolution"
+        wdelta : "!SIM.spectral.spectral_bin_width"
 
 -   name : micado_system_ter_curve
     class : TERCurve

--- a/MICADO_ETC/default.yaml
+++ b/MICADO_ETC/default.yaml
@@ -2,7 +2,9 @@
 # description: default observation parameters for MICADO-Sci
 # author : Kieran Leschinski
 # date_created : 2020-07-09
-# date_modified : 2020-08-17
+# date_modified : 2022-01-12
+# changes:
+#   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 object : configuration
 alias : OBS
@@ -38,7 +40,7 @@ properties :
     wave_min : 0.7
     wave_mid : 1.6
     wave_max : 2.5
-    spectral_resolution : 0.001
+    spectral_bin_width : 0.001
 
   computing :
     preload_field_of_view : True

--- a/MICADO_Sci/MICADO_Sci.yaml
+++ b/MICADO_Sci/MICADO_Sci.yaml
@@ -2,7 +2,9 @@
 # description: default observation parameters for MICADO-Sci
 # author: Kieran Leschinski
 # date_created: 09.07.2020
-# date_modified: 09.07.2020
+# date_modified: 2022-01-12
+# changes:
+#   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 #
 # contains:
 # - System transmission
@@ -57,7 +59,7 @@ effects :
 #        wmin: "!SIM.spectral.wave_min"
 #        wmax: "!SIM.spectral.wave_max"
 #        wunit: um
-#        wdelta: "!SIM.spectral.spectral_resolution"
+#        wdelta: "!SIM.spectral.spectral_bin_width"
 
 
 ---

--- a/MICADO_Sci/default.yaml
+++ b/MICADO_Sci/default.yaml
@@ -2,8 +2,9 @@
 # description: default observation parameters for MICADO-Sci
 # author : Kieran Leschinski
 # date_created : 2020-07-09
-# date_modified : 2020-08-17
-
+# date_modified : 2022-01-12
+# changes:
+#   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 object : configuration
 alias : OBS
 name : MICADO_sci_default_configuration
@@ -85,7 +86,7 @@ properties :
     wave_min : 0.7
     wave_mid : 1.6
     wave_max : 2.5
-    spectral_resolution : 0.001
+    spectral_bin_width : 0.001
 
   computing :
     preload_field_of_view : True

--- a/Paranal/Paranal.yaml
+++ b/Paranal/Paranal.yaml
@@ -3,6 +3,9 @@ object : atmosphere
 alias : ATMO
 name : paranal
 description : Atmosphere and location details for Paranal
+date-modified: 2022-01-12
+changes:
+  - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 properties :
     altitude :      2635        # m
@@ -26,7 +29,7 @@ effects :
           wmin: "!SIM.spectral.wave_min"
           wmax: "!SIM.spectral.wave_max"
           wunit: um
-          wdelta: "!SIM.spectral.spectral_resolution"
+          wdelta: "!SIM.spectral.spectral_bin_width"
 
 
 ####################### Alternative effects ####################################


### PR DESCRIPTION
Renamed `spectral_resolution` to `spectral_bin_width` in accord with changes made in scopesim. This frees up `spectral_resolution` to give what it promises to give, i.e. lambda/dlambda (used in `METIS_LSS.yaml`).