### PR TITLE
Kl/feature/det prop setter

### DIFF
--- a/Armazones/Armazones.yaml
+++ b/Armazones/Armazones.yaml
@@ -8,6 +8,7 @@ changes:
   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 properties :
+    location :      Armazones
     altitude :      3060        # m
     longitude :     -70.1918    # deg
     latitude :      -24.5899    # deg

--- a/ELT/ELT.yaml
+++ b/ELT/ELT.yaml
@@ -5,6 +5,7 @@ name : ELT
 description : The extremely large telescope
 
 properties :
+    telescope :   ELT
     temperature : "!ATMO.temperature"
     ter_curve:
         filename : "TER_ELT_5_mirror.dat"

--- a/METIS/FPA_linearity_GeoSnap_high_capacity.dat
+++ b/METIS/FPA_linearity_GeoSnap_high_capacity.dat
@@ -1,8 +1,8 @@
-# name : Geosnap linearity curve
+# name : Geosnap high_capacity linearity curve
 # author : Oliver Czoske
 # sources: E-REP-NOVA-MET-1191_2-0
 # date_created : 2021-04-01
-# date_modified : 2021-12-13
+# date_modified : 2022-01-26
 # type : detector:linearity
 # status : Teledyne specs, high-capacity mode
 # incident_unit : e
@@ -11,6 +11,8 @@
 #
 # changes :
 #    - 2021-12-13 (OC) units converted to electrons
+#    - 2022-01-26 (OC) modified name
+#
 incident    measured
 0           0
 2.8e6       2.8e6

--- a/METIS/FPA_linearity_GeoSnap_low_capacity.dat
+++ b/METIS/FPA_linearity_GeoSnap_low_capacity.dat
@@ -1,0 +1,17 @@
+# name : Geosnap low_capacity linearity curve
+# author : Oliver Czoske
+# sources: Roy van Boekel
+# date_created : 2022-01-26
+# date_modified : 2022-01-26
+# type : detector:linearity
+# status : Teledyne specs, low-capacity mode
+# incident_unit : e
+# measured_unit : e
+# ndit : 1
+#
+# changes :
+#
+incident    measured
+0           0
+1.8e5       1.8e5
+1e99        1.8e5

--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -55,7 +55,6 @@ effects:
       minimum_throughput: !!float 0.
 
 
-
 #  - name : metis_adc_residuals
 #    class : AtmosphericDispersionCorrection
 #    include : False

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -4,20 +4,18 @@ object: detector
 alias: DET
 name: metis_img_lm_detector_array
 description: A single H2RG detector
-date_modified: 2021-12-16
+date_modified: 2021-12-26
 changes:
   - 2021-12-16 (OC) some rearrangements
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
+  - 2022-01-26 (OC) added DET.detector
 
 properties:
+  detector:  HAWAII2RG
   image_plane_id: 0
   temperature: -230
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  mindit: 0.04              # seconds, E-TNT-MPIA-1004, v1-0
-  full_well: !!float 1.E5   # electrons, E-TNT-MPIA-1004, v1-0
-  dark_current: 0.1         # [e-/s]
-  readout_noise: 12
   layout:
     file_name: "FPA_metis_img_lm_layout.dat"
   qe_curve:
@@ -29,26 +27,26 @@ effects:
   - name: detector_array_list
     description: METIS IMG-LM detector array list
     class: DetectorList
-    include: true
     kwargs:
       file_name: "!DET.layout.file_name"
 
-
-################################## TBD
   - name: detector_readout_parameters
-    desription:
+    description: Readout modes for H2RG detector
     class: DetectorModePropertiesSetter
     kwargs:
       mode_properties:
         fast:
-          min_dit: 0.04
-          full_well: !!float 1e5
-          ron: 70
+          description: "HAWAII2RG, fast mode"
+          "!DET.mindit": 0.04
+          "!DET.full_well": !!float 1e5
+          "!DET.readout_noise": 70
+          "!DET.dark_current": 0.05
         slow:
-          min_dit: 1.3
-          full_well: !!float 1e5
-          ron: 14
-
+          description: "HAWAII2RG, slow mode"
+          "!DET.mindit": 1.3
+          "!DET.full_well": !!float 1e5
+          "!DET.readout_noise": 15
+          "!DET.dark_current": 0.05
 
   - name: qe_curve
     description: Quantum efficiency curves for each detector
@@ -62,6 +60,8 @@ effects:
     include: true
     kwargs:
       fill_frac: "!OBS.auto_exposure.fill_frac"
+      full_well: "!DET.full_well"
+      mindit: "!DET.mindit"
 
   - name: exposure_action
     description: Summing up sky signal for all DITs and NDITs

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -7,6 +7,7 @@ description: A single H2RG detector
 date_modified: 2021-12-16
 changes:
   - 2021-12-16 (OC) some rearrangements
+  - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
 
 properties:
   image_plane_id: 0
@@ -35,17 +36,18 @@ effects:
 
 ################################## TBD
   - name: detector_readout_parameters
-      class: DetectorModePropertiesSetter
-  - kwargs:
+    desription:
+    class: DetectorModePropertiesSetter
+    kwargs:
       mode_properties:
         fast:
           min_dit: 0.04
           full_well: !!float 1e5
           ron: 70
         slow:
-          min_dit: 0.04
+          min_dit: 1.3
           full_well: !!float 1e5
-          ron: 70
+          ron: 14
 
 
   - name: qe_curve

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -32,6 +32,22 @@ effects:
     kwargs:
       file_name: "!DET.layout.file_name"
 
+
+################################## TBD
+  - name: detector_readout_parameters
+      class: DetectorModePropertiesSetter
+  - kwargs:
+      mode_properties:
+        fast:
+          min_dit: 0.04
+          full_well: !!float 1e5
+          ron: 70
+        slow:
+          min_dit: 0.04
+          full_well: !!float 1e5
+          ron: 70
+
+
   - name: qe_curve
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -6,8 +6,10 @@ name: metis_detector_array
 description: Aquarius detector for METIS IMG-NQ
 changes:
   - 2021-12-16 (OC) some rearrangements
+  - 2022-12-26 (OC) added DetectorModePropertiesSetter and DET.detector
 
 properties:
+  detector: Raytheon Aquarius
   temperature: -265
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
@@ -28,6 +30,22 @@ effects:
     class: DetectorList
     kwargs:
       file_name: "!DET.layout.file_name"
+
+  - name: detector_readout_parameters
+    description: Readout modes for Aquarius detector
+    class: DetectorModePropertiesSetter
+    kwargs:
+      mode_properties:
+        low_gain:
+          "!DET.mindit":    0.008        # seconds
+          "!DET.full_well": !!float 9e6  # electrons
+          "!DET.readout_noise": 1400     # electrons (DCS)
+          "!DET.dark_current":  13       # electrons/second
+        high_gain:
+          "!DET.mindit":    0.008        # seconds
+          "!DET.full_well": !!float 1e6  # electrons
+          "!DET.readout_noise": 150      # electrons (DCS)
+          "!DET.dark_current": 13        # electrons/second
 
   - name: qe_curve
     description: Quantum efficiency curves for each detector

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -4,25 +4,22 @@ object: detector
 alias: DET
 name: metis_detector_array
 description: Teledyne GeoSnap Detector
-date_modified: 2021-12-16
+date_modified: 2021-12-26
 changes:
   - 2021-12-16 (OC) some rearrangements, chopnod off by default
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
+  - 2022-01-26 (OC) added DET.detector, linearity set explicitely
 
 properties:
+  detector: Teledyne GeoSnap
+  image_plane_id: 0
   temperature: -240
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  mindit: 0.011               # seconds, E-REP-NOVA-MET-1191, v2-0
-  full_well: !!float 2.8e6    # electrons, E-REP-NOVA-MET-1191, v2-0
-  dark_current: !!float 1.e5  # [e-/s], E-REP-NOVA-MET-1191, v2-0
-  readout_noise: 12
   layout:
     file_name: "FPA_metis_img_n_geosnap_layout.dat"
   qe_curve:
     file_name: "QE_detector_geosnap.dat"
-  linearity:
-    file_name: "FPA_linearity_GeoSnap.dat"
 
 effects:
   - name: detector_array_list
@@ -31,23 +28,27 @@ effects:
     kwargs:
       file_name: "!DET.layout.file_name"
 
-
-
-################################## TBD
   - name: detector_readout_parameters
-    desription:
+    description: Readout modes for Geosnap detector
     class: DetectorModePropertiesSetter
     kwargs:
       mode_properties:
-        high:
-          min_dit: 0.04
-          full_well: !!float 1e5
-          ron: 70
-        low:
-          "!DET.min_dit": 1.3
-          "!DET.full_well": !!float 1e5
-          ron: 14
-
+        high_capacity:
+          description:               "Geosnap, high-capacity mode"
+          "!DET.mindit":             0.011          # seconds
+          "!DET.full_well":          !!float 2.8e6  # electrons
+          "!DET.readout_noise":      300            # electrons (DCS)
+          "!DET.dark_current":       !!float 1e5    # electrons/second
+          "!DET.linearity.incident": [0, !!float 2.8e6, !!float 1e99]
+          "!DET.linearity.measured": [0, !!float 2.8e6, !!float 2.8e6]
+        low_capacity:
+          description:               "Geosnap, low-capacity mode"
+          "!DET.mindit":             0.011          # seconds
+          "!DET.full_well":          !!float 1.8e5  # electrons
+          "!DET.readout_noise":      35             # electrons (DCS)
+          "!DET.dark_current":       !!float 1e5    # electrons/second
+          "!DET.linearity.incident": [0, !!float 1.8e5, !!float 1e99]
+          "!DET.linearity.measured": [0, !!float 1.8e5, !!float 1.8e5]
 
   - name: qe_curve
     description: Quantum efficiency curves for each detector
@@ -61,6 +62,8 @@ effects:
     include: true
     kwargs:
       fill_frac: "!OBS.auto_exposure.fill_frac"
+      full_well: "!DET.full_well"
+      mindit: "!DET.mindit"
 
   - name: exposure_action
     description: Summing up sky signal for all DITs and NDITs
@@ -80,7 +83,8 @@ effects:
     description: Linearity characteristics of GeoSnap chip
     class: LinearityCurve
     kwargs:
-      filename: "!DET.linearity.file_name"
+      incident: "!DET.linearity.incident"
+      measured: "!DET.linearity.measured"
 
   - name: readout_noise
     description: Readout noise frames

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -7,6 +7,7 @@ description: Teledyne GeoSnap Detector
 date_modified: 2021-12-16
 changes:
   - 2021-12-16 (OC) some rearrangements, chopnod off by default
+  - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
 
 properties:
   temperature: -240
@@ -34,19 +35,18 @@ effects:
 
 ################################## TBD
   - name: detector_readout_parameters
-      class: DetectorModePropertiesSetter
-  - kwargs:
+    desription:
+    class: DetectorModePropertiesSetter
+    kwargs:
       mode_properties:
         high:
           min_dit: 0.04
           full_well: !!float 1e5
           ron: 70
         low:
-          "!DET.min_dit": 0.04
+          "!DET.min_dit": 1.3
           "!DET.full_well": !!float 1e5
-          ron: 70
-
-
+          ron: 14
 
 
   - name: qe_curve

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -30,6 +30,25 @@ effects:
     kwargs:
       file_name: "!DET.layout.file_name"
 
+
+
+################################## TBD
+  - name: detector_readout_parameters
+      class: DetectorModePropertiesSetter
+  - kwargs:
+      mode_properties:
+        high:
+          min_dit: 0.04
+          full_well: !!float 1e5
+          ron: 70
+        low:
+          "!DET.min_dit": 0.04
+          "!DET.full_well": !!float 1e5
+          ron: 70
+
+
+
+
   - name: qe_curve
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -7,6 +7,7 @@ description: additional effects for METIS long-slit spectroscopy
 date_modified: 2022-01-12
 changes:
   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
+
 properties:
     decouple_detector_from_sky_headers: True
 
@@ -32,13 +33,6 @@ effects:
       s_colname: "xi"
       col_number_start: 1
       decouple_sky_detector_headers: True
-
-########################## TBD
-    - name: lms_detector_properties
-      class: DetectorModePropertiesSetter
-      kwargs:
-        set_mode: "!OBS.detector_readout_mode"
-
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -33,6 +33,13 @@ effects:
       col_number_start: 1
       decouple_sky_detector_headers: True
 
+########################## TBD
+    - name: lms_detector_properties
+      class: DetectorModePropertiesSetter
+      kwargs:
+        set_mode: "!OBS.detector_readout_mode"
+
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -48,6 +48,7 @@ mode_yamls:
       nd_filter_name: open
       slit: false
       adc: const_90
+      detector_readout_mode: fast
 
   - object: observation
     alias: OBS
@@ -64,6 +65,7 @@ mode_yamls:
       adc: false
       chop_offsets: [3, 0]  # perpendicular chopping and nodding
       nod_offsets: [0, 3]
+      detector_readout_mode: high
 
   - object: observation
     alias: OBS
@@ -80,7 +82,7 @@ mode_yamls:
       adc: const_90
       filter_name: L_spec
       nd_filter_name: open
-      detector_readout_mode: hawaii_slow   # ######## TBD   !OBS.detector_mode_name
+      detector_readout_mode: slow
 
   - object: observation
     alias: OBS
@@ -97,6 +99,7 @@ mode_yamls:
       adc: const_90
       filter_name: M_spec
       nd_filter_name: open
+      detector_readout_mode: slow
 
   - object: observation
     alias: OBS
@@ -113,6 +116,7 @@ mode_yamls:
       adc: false
       filter_name: N_spec
       nd_filter_name: open
+      detector_readout_mode: low
 
   - object: observation
     alias: OBS
@@ -127,6 +131,7 @@ mode_yamls:
       adc: false
       trace_file: TRACE_LMS.fits
       wavelen: 4.2
+      detector_readout_mode: slow
 
   - object: observation     # is this a separate mode from nominal LMS?
     alias: OBS
@@ -138,6 +143,7 @@ mode_yamls:
     properties:
       slit: false
       adc: false
+      detector_readout_mode: slow
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -5,12 +5,13 @@ object: configuration
 alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
-date_modified: 2022-01-10
+date_modified: 2022-01-25
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
   - 2021-12-16 (OC) default slits renamed
   - 2022-01-07 (OC) trace files default to science version
   - 2022-01-10 (OC) adc defaults to false for N band
+  - 2022-01-25 (OC, KL) add detector modes
 
 packages:
   - Armazones
@@ -23,6 +24,7 @@ yamls:
   - METIS.yaml
 
 properties:
+  instrument: "METIS"
   modes: ["img_lm"]
   airmass: 1.2
   declination: -30
@@ -65,7 +67,7 @@ mode_yamls:
       adc: false
       chop_offsets: [3, 0]  # perpendicular chopping and nodding
       nod_offsets: [0, 3]
-      detector_readout_mode: high
+      detector_readout_mode: high_capacity
 
   - object: observation
     alias: OBS
@@ -116,7 +118,7 @@ mode_yamls:
       adc: false
       filter_name: N_spec
       nd_filter_name: open
-      detector_readout_mode: low
+      detector_readout_mode: low_capacity
 
   - object: observation
     alias: OBS

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -80,6 +80,7 @@ mode_yamls:
       adc: const_90
       filter_name: L_spec
       nd_filter_name: open
+      detector_readout_mode: hawaii_slow   # ######## TBD   !OBS.detector_mode_name
 
   - object: observation
     alias: OBS


### PR DESCRIPTION
- Detector readout mode definitions in METIS
- added `name` properties to ELT and Armazones to make them identifiable in `UserCommands`, in view of adding those to FITS headers of data products