### PR TITLE
removed hardcoded password. see emails

### DIFF
--- a/MICADO/test_micado/test_detector_array_and_traces_plot.py
+++ b/MICADO/test_micado/test_detector_array_and_traces_plot.py
@@ -1,0 +1,34 @@
+from matplotlib import pyplot as plt
+from astropy.io import fits, ascii
+from astropy.table import Table
+
+
+class TestSpecTraceVsDetectors:
+    def test_plot_detectors(self):
+        tbl = ascii.read("../FPA_array_layout.dat")
+        print(tbl)
+
+        plt.figure(figsize=(7, 7))
+        for row in tbl:
+            x, y = row["x_cen"], row["y_cen"]
+            dx, dy =  row["xhw"], row["yhw"]
+            plt.plot([x-dx, x+dx, x+dx, x-dx, x-dx],
+                     [y-dy, y-dy, y+dy, y+dy, y-dy], c="b")
+            plt.text(x, y, row["id"], horizontalalignment="center", verticalalignment="center", fontsize=18)
+
+        for ext in range(2, 3):
+            tbl = Table(fits.getdata("../TRACE_MICADO.fits", ext=ext))
+            plt.scatter(tbl["x"], tbl["y"], c=tbl["wavelength"], s=10, cmap="hot_r")
+
+            plt.text(tbl["x"][3], tbl["y"][3], f'{round(tbl["wavelength"][3], 2)} um', horizontalalignment="center", verticalalignment="center", fontsize=14)
+            plt.text(tbl["x"][-2], tbl["y"][-2], f'{round(tbl["wavelength"][-2], 2)} um', horizontalalignment="center", verticalalignment="center", fontsize=14)
+
+
+        plt.arrow(0, 5, 0, 20, width=1, fc="k")
+        plt.arrow(5, 0, 20, 0, width=1, fc="k")
+
+        plt.xlabel("X distance from optical axis [mm]")
+        plt.ylabel("Y distance from optical axis [mm]")
+        plt.title("SimCADO detector layout (May 2021)\nLooking through the bottom of the detector towards the sky")
+
+        plt.show()

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -6,7 +6,6 @@ from datetime import datetime as dt
 import yaml
 import pysftp
 
-
 PKGS_DIR = pth.abspath(pth.join(pth.dirname(__file__), "../"))
 OLD_FILES = pth.join(PKGS_DIR, "_OLD_FILES")
 ZIPPED_DIR = pth.join(PKGS_DIR, "_ZIPPED_PACKAGES")
@@ -16,7 +15,7 @@ with open(pth.join(pth.dirname(__file__), "packages.yaml"), "r") as f:
     PKGS = yaml.full_load(f)
 
 
-def publish(pkg_names=None, compile=True, upload=True):
+def publish(pkg_names=None, compile=True, upload=True, password=None):
     """
     Should be as easy as just calling this function to republish all packages
 
@@ -27,6 +26,7 @@ def publish(pkg_names=None, compile=True, upload=True):
     pkg_names : list
     compile : bool
     upload : bool
+    password : str
 
     """
     if pkg_names is None:
@@ -34,7 +34,7 @@ def publish(pkg_names=None, compile=True, upload=True):
 
     for pkg_name in pkg_names:
         if compile: make_packages(pkg_name)
-        if upload: push_to_server(pkg_name)
+        if upload: push_to_server(pkg_name, password=password)
 
 
 def make_packages(pkg_names=()):
@@ -78,8 +78,11 @@ def zip_package_folder(pkg_name):
     return new_pkg_path
 
 
-def push_to_server(pkg_name):
-    local_path = pth.join(ZIPPED_DIR, pkg_name+".zip")
+def push_to_server(pkg_name, password=None):
+    if password is None:
+        raise ValueError("Password is None. Check email for password")
+
+    local_path = pth.join(ZIPPED_DIR, pkg_name + ".zip")
 
     if pkg_name not in PKGS:
         raise ValueError(f"{pkg_name} was not found in 'irdb/packages.yaml'")
@@ -87,7 +90,7 @@ def push_to_server(pkg_name):
     cnopts = pysftp.CnOpts()
     cnopts.hostkeys = None
     sftp = pysftp.Connection(host="upload.univie.ac.at", username="simcado",
-                             password="M1(aDo(aM", cnopts=cnopts)
+                             password=password, cnopts=cnopts)
     with sftp.cd("html/InstPkgSvr/"):
         if sftp.exists(PKGS[pkg_name]):
             sftp.remove(PKGS[pkg_name])
@@ -97,9 +100,9 @@ def push_to_server(pkg_name):
 
 def print_help_menu():
     str = """Publish IRDB packages from the IRDB root directory:
-    
+
 python irdb/publish.py -cu <PKG_NAME> ... <PKG_NAME_N>
-    
+
     -c, --compile : adds all files in a PKG folder to a .zip archive
     -u, --upload : uploads the PKG .zip archive to the server
     -h, --help : prints this statement 
@@ -111,8 +114,10 @@ if __name__ == "__main__":
     _pkg_names = []
     if len(sys.argv) > 1:
         kwargs = {"compile": False, "upload": False}
-        for arg in sys.argv[1:]:
+        argv_iter = iter(sys.argv[1:])
+        for arg in argv_iter:
             if "-" in arg:
+                if "p" in arg: kwargs["password"] = next(argv_iter)
                 if "c" in arg: kwargs["compile"] = True
                 if "u" in arg: kwargs["upload"] = True
                 if "h" in arg: print_help_menu()

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -101,8 +101,9 @@ def push_to_server(pkg_name, password=None):
 def print_help_menu():
     str = """Publish IRDB packages from the IRDB root directory:
 
-python irdb/publish.py -cu <PKG_NAME> ... <PKG_NAME_N>
+    $ python irdb/publish.py -cu <PKG_NAME> ... <PKG_NAME_N> -p <PASSWORD>
 
+    -p <password> : pass the univie server password for uploading zip files
     -c, --compile : adds all files in a PKG folder to a .zip archive
     -u, --upload : uploads the PKG .zip archive to the server
     -h, --help : prints this statement 


### PR DESCRIPTION
Removes the potential security bug for the IRDB packages on the unive server

Packages must now be compiles and uploaded with the addition of a password (see email conversation) by using the `-p` tag in the command line

Old: 
`$ python irdb/publish.py -cu <PKG_NAME> ... <PKG_NAME_N>`

New:
`$ python irdb/publish.py -cu <PKG_NAME> ... <PKG_NAME_N> -p <PASSWORD>`