### PR TITLE
oc/cleaner compile

### DIFF
--- a/Armazones/Armazones.yaml
+++ b/Armazones/Armazones.yaml
@@ -3,9 +3,10 @@ object : atmosphere
 alias : ATMO
 name : armazones
 description : Atmosphere and location details for Cerro Armazones
-date-modified: 2022-01-12
+date-modified: 2022-02-21
 changes:
   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
+  - 2022-02-21 (OC) commented out unused effects for the time being
 
 properties :
     location :      Armazones
@@ -27,7 +28,7 @@ properties :
         filename: "TER_armazones_default_FULL_IMG.dat"
 
 effects :
--   name : armazones_atmo_skycalc_ter_curve
+-   name : skycalc_atmosphere
     description : atmospheric spectra pulled from the skycalc server
     class : SkycalcTERCurve
     include : True
@@ -39,22 +40,22 @@ effects :
         wres : "!SIM.spectral.spectral_resolution"
         wdelta: "!SIM.spectral.spectral_bin_width"
 
--   name : armazones_atmo_dispersion
-    description : atmospheric dispersion
-    class : AtmosphericDispersion
-    include : False
+#-   name : armazones_atmo_dispersion
+#    description : atmospheric dispersion
+#    class : AtmosphericDispersion
+#    include : False
 
 
 ####################### Alternative effects ####################################
--   name : armazones_atmo_default_ter_curve
-    description : atmospheric emission and transmission
-    class : AtmosphericTERCurve
-    include : False
-    kwargs :
-        filename: "!ATMO.spectrum.filename"
-        area: "!TEL.area"
-        rescale_emission:
-            filter_name: "!ATMO.background.filter_name"
-            filename_format: "!INST.filter_file_format"
-            value: "!ATMO.background.value"
-            unit: "!ATMO.background.unit"
+#-   name : armazones_atmo_default_ter_curve
+#    description : atmospheric emission and transmission
+#    class : AtmosphericTERCurve
+#    include : False
+#    kwargs :
+#        filename: "!ATMO.spectrum.filename"
+#        area: "!TEL.area"
+#        rescale_emission:
+#            filter_name: "!ATMO.background.filter_name"
+#            filename_format: "!INST.filter_file_format"
+#            value: "!ATMO.background.value"
+#            unit: "!ATMO.background.unit"

--- a/Armazones/Armazones.yaml
+++ b/Armazones/Armazones.yaml
@@ -7,6 +7,7 @@ date-modified: 2022-02-21
 changes:
   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
   - 2022-02-21 (OC) commented out unused effects for the time being
+  - 2022-02-21 (OC) set skycalc grid mode to logarithmic
 
 properties :
     location :      Armazones
@@ -37,6 +38,7 @@ effects :
         wmin : "!SIM.spectral.wave_min"
         wmax : "!SIM.spectral.wave_max"
         wunit : um
+        wgrid_mode: fixed_spectral_resolution   # ['fixed_spectral_resolution','fixed_wavelength_step']
         wres : "!SIM.spectral.spectral_resolution"
         wdelta: "!SIM.spectral.spectral_bin_width"
 

--- a/ELT/ELT.yaml
+++ b/ELT/ELT.yaml
@@ -1,39 +1,42 @@
-### ELT TELESCOPE
+### Config file for the ELT telescope
 object : telescope
 alias : TEL
 name : ELT
 description : The extremely large telescope
+date-modified: 2022-02-21
+changes:
+  - 2022-02-21 (OC) commented out unused effects
 
 properties :
-    telescope :   ELT
-    temperature : "!ATMO.temperature"
-    ter_curve:
-        filename : "TER_ELT_5_mirror.dat"
+  telescope :   ELT
+  temperature : "!ATMO.temperature"
+  ter_curve:
+    filename : "TER_ELT_5_mirror.dat"
 
 effects :
--   name : eso_combined_reflection
+  - name : telescope_reflection
     description : single combined reflection curve (ESO-333023)
     class : SurfaceList
     include : True
     kwargs :
-        filename : LIST_ELT_combined.tbl
+      filename : LIST_ELT_combined.tbl
 
--   name : scope_vibration
-    description : residual vibration of telescope
-    class : Vibration
-    include : False
-    kwargs :
-        fwhm : 0.001    # [arcsec] FWHM of Gaussian kernel
-        pixel_scale : "!INST.pixel_scale"
+#  - name : scope_vibration
+#    description : residual vibration of telescope
+#    class : Vibration
+#    include : False
+#    kwargs :
+#      fwhm : 0.001    # [arcsec] FWHM of Gaussian kernel
+#      pixel_scale : "!INST.pixel_scale"
 
 
 ####################### Alternative effects ####################################
 
 ## scope_surface_list builds the telescope one by one. This should give
 ## about the same throughput as eso_combined_throughput
--   name : scope_surface_list
-    description : list of ELT surfaces
-    class : SurfaceList
-    include : False
-    kwargs :
-        filename : LIST_mirrors_ELT.tbl
+#-   name : scope_surface_list
+#    description : list of ELT surfaces
+#    class : SurfaceList
+#    include : False
+#    kwargs :
+#        filename : LIST_mirrors_ELT.tbl

--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -5,15 +5,15 @@ object: instrument
 alias: INST
 name: METIS
 description: base configuration for METIS
-date_modified: 2022-01-05
+date_modified: 2022-02-20
 changes:
   - 2021-12-16 (OC) temperature changed to align with cfo
   - 2021-12-16 (OC) slit files renamed to include slit width
   - 2022-01-05 (OC) add ADC wheel
+  - 2022-02-20 (OC) pupil_transmission now an OBS parameter
 
 properties:
   temperature: -206
-  pupil_transmission: 1.0
 
 effects:
   - name: metis_cfo_surfaces
@@ -51,7 +51,7 @@ effects:
     class: PupilTransmission
     include: True
     kwargs:
-      transmission: "!INST.pupil_transmission"
+      transmission: "!OBS.pupil_transmission"
       minimum_throughput: !!float 0.
 
 

--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -5,19 +5,20 @@ object: instrument
 alias: INST
 name: METIS
 description: base configuration for METIS
-date_modified: 2022-02-20
+date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) temperature changed to align with cfo
   - 2021-12-16 (OC) slit files renamed to include slit width
   - 2022-01-05 (OC) add ADC wheel
   - 2022-02-20 (OC) pupil_transmission now an OBS parameter
+  - 2022-02-21 (OC) name change cfo effect
 
 properties:
   temperature: -206
 
 effects:
-  - name: metis_cfo_surfaces
-    description: surface list for common fore optics
+  - name: common_fore_optics
+    description: surface list for METIS common fore optics
     class: SurfaceList
     kwargs:
       filename: LIST_METIS_mirrors_cfo.dat
@@ -53,7 +54,6 @@ effects:
     kwargs:
       transmission: "!OBS.pupil_transmission"
       minimum_throughput: !!float 0.
-
 
 #  - name : metis_adc_residuals
 #    class : AtmosphericDispersionCorrection

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -2,13 +2,14 @@
 ### H2RG DETECTOR
 object: detector
 alias: DET
-name: metis_img_lm_detector_array
+name: METIS_DET_IMG_LM
 description: A single H2RG detector
 date_modified: 2021-12-26
 changes:
   - 2021-12-16 (OC) some rearrangements
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
   - 2022-01-26 (OC) added DET.detector
+  - 2022-02-21 (OC) rename effects
 
 properties:
   detector:  HAWAII2RG
@@ -24,14 +25,14 @@ properties:
     file_name: "FPA_linearity_HxRG.dat"
 
 effects:
-  - name: detector_array_list
+  - name: detector_array
     description: METIS IMG-LM detector array list
     class: DetectorList
     kwargs:
       file_name: "!DET.layout.file_name"
 
   - name: detector_readout_parameters
-    description: Readout modes for H2RG detector
+    description: Readout parameters for H2RG detector (fast and slow modes)
     class: DetectorModePropertiesSetter
     kwargs:
       mode_properties:
@@ -48,7 +49,7 @@ effects:
           "!DET.readout_noise": 15
           "!DET.dark_current": 0.05
 
-  - name: qe_curve
+  - name: quantum_efficiency
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
@@ -63,7 +64,7 @@ effects:
       full_well: "!DET.full_well"
       mindit: "!DET.mindit"
 
-  - name: exposure_action
+  - name: summed_exposure
     description: Summing up sky signal for all DITs and NDITs
     class: SummedExposure
 

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -2,11 +2,13 @@
 ### Aquarius DETECTOR
 object: detector
 alias: DET
-name: metis_detector_array
+name: METIS_DET_IMG_N_Aquarius
 description: Aquarius detector for METIS IMG-NQ
+date-modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) some rearrangements
-  - 2022-12-26 (OC) added DetectorModePropertiesSetter and DET.detector
+  - 2021-12-26 (OC) added DetectorModePropertiesSetter and DET.detector
+  - 2022-02-21 (OC) rename effects
 
 properties:
   detector: Raytheon Aquarius
@@ -25,7 +27,7 @@ properties:
     file_name: "FPA_linearity_Aquarius.dat"
 
 effects:
-  - name: detector_array_list
+  - name: detector_array
     description: METIS detector array list
     class: DetectorList
     kwargs:
@@ -47,7 +49,7 @@ effects:
           "!DET.readout_noise": 150      # electrons (DCS)
           "!DET.dark_current": 13        # electrons/second
 
-  - name: qe_curve
+  - name: quantum_efficiency
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     include: false    # QE file does not exist
@@ -61,7 +63,7 @@ effects:
     kwargs:
       fill_frac: "!OBS.auto_exposure.fill_frac"
 
-  - name: exposure_action
+  - name: summed_exposure
     description: Summing up sky signal for all DITs and NDITs
     class: SummedExposure
 
@@ -88,7 +90,7 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 64
 
-  - name: chopnod
+  - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
     include: false

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -2,13 +2,14 @@
 ### GeoSnap DETECTOR
 object: detector
 alias: DET
-name: metis_detector_array
+name: METIS_DET_IMG_N_GeoSnap
 description: Teledyne GeoSnap Detector
-date_modified: 2021-12-26
+date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) some rearrangements, chopnod off by default
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
   - 2022-01-26 (OC) added DET.detector, linearity set explicitely
+  - 2022-02-21 (OC) rename effects
 
 properties:
   detector: Teledyne GeoSnap
@@ -22,14 +23,14 @@ properties:
     file_name: "QE_detector_geosnap.dat"
 
 effects:
-  - name: detector_array_list
+  - name: detector_array
     description: METIS IMG-N detector array list
     class: DetectorList
     kwargs:
       file_name: "!DET.layout.file_name"
 
   - name: detector_readout_parameters
-    description: Readout modes for Geosnap detector
+    description: Readout modes for Geosnap detector (high and low capacity)
     class: DetectorModePropertiesSetter
     kwargs:
       mode_properties:
@@ -50,7 +51,7 @@ effects:
           "!DET.linearity.incident": [0, !!float 1.8e5, !!float 1e99]
           "!DET.linearity.measured": [0, !!float 1.8e5, !!float 1.8e5]
 
-  - name: qe_curve
+  - name: quantum_efficiency
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
@@ -65,7 +66,7 @@ effects:
       full_well: "!DET.full_well"
       mindit: "!DET.mindit"
 
-  - name: exposure_action
+  - name: summed_exposure
     description: Summing up sky signal for all DITs and NDITs
     class: SummedExposure
 
@@ -93,7 +94,7 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 8
 
-  - name: chopnod
+  - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
     include: false

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -5,12 +5,13 @@ object: instrument
 alias: INST
 name: METIS_IMG_LM
 description: base configuration for METIS
-date_modified: 2022-01-17
+date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) filter_file_format moved here
   - 2022-01-11 (OC) change default bkg_width to 0
   - 2022-01-12 (OC) change default bkg_width to -1
   - 2022-02-17 (OC) increase spectral_bin_width for imaging
+  - 2022-02-21 (OC) renamed effects
 
 properties:
   pixel_scale: 0.00547         # arcsec / pixel, METIS_1097
@@ -18,14 +19,14 @@ properties:
   filter_file_format: "filters/TC_filter_{}.dat"
 
 effects:
-  - name: metis_img_lm_mirror_list
-    description: list of extra mirrors needed for the LM IMG mode
+  - name: img_lm_optics
+    description: list of extra mirrors in METIS LM imager
     class: SurfaceList
     kwargs:
       filename: LIST_METIS_mirrors_img_lm.dat
 
   - name: filter_wheel
-    description: IMG_LM science filters
+    description: IMG_LM science filters (E-REP-MPIA-MET-1008_1-0)
     class: FilterWheel
     kwargs:
       filter_names:
@@ -55,7 +56,7 @@ effects:
 
   - name: nd_filter_wheel
     class: FilterWheel
-    description: IMG_LM neutral density filters
+    description: IMG_LM neutral density filters (E-REP-MPIA-MET-1008_1-0)
     kwargs:
       filter_names:
         # 11 positions (E-REP-MPIA-MET-1008_1-0)
@@ -72,7 +73,7 @@ effects:
       outer: 56                                # E-REP-MPIA-MET-1008_1-0
       outer_unit: "mm"
 
-  - name: metis_psf_img
+  - name: psf
     description: field constant, wavelength dependent PSF for imaging mode
     class: FieldConstantPSF
     kwargs:
@@ -89,5 +90,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 1E-3   # microns (spectral bin width)
-    spectral_resolution: 5000
+    spectral_bin_width: !!float 1E-3   # microns, defines fov wavelengths
+    spectral_resolution: 5000          # defines skycalc resolution

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -4,7 +4,7 @@
 object: instrument
 alias: INST
 name: METIS_IMG_LM
-description: base configuration for METIS
+description: base configuration for METIS LM band imager
 date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) filter_file_format moved here

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -1,78 +1,79 @@
 ---
-### METIS N-band IMAGING MODE
+### METIS N IMAGING MODE
 object: instrument
 alias: INST
 name: METIS_IMG_N
-description: base configuration for METIS
-date_modified: 2022-02-17
+description: base configuration for METIS N band imager
+date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) filter_file_format moved here
   - 2022-01-11 (OC) change default bkg_width to 0
   - 2022-01-12 (OC) change default bkg_width to -1
   - 2022-02-17 (OC) increase spectral_bin_width for imaging
+  - 2022-02-21 (OC) rename effects
 
 properties:
-    pixel_scale: 0.00679         # arcsec / pixel, METIS-1097
-    plate_scale: 0.377222222222  # arcsec / mm
-    filter_file_format: "filters/TC_filter_{}.dat"
+  pixel_scale: 0.00679         # arcsec / pixel, METIS-1097
+  plate_scale: 0.377222222222  # arcsec / mm
+  filter_file_format: "filters/TC_filter_{}.dat"
 
 effects:
-    - name: metis_img_n_mirror_list
-      description: list of extra mirrors needed for the N IMG mode
-      class: SurfaceList
-      kwargs:
-          filename: LIST_METIS_mirrors_img_n.dat
+  - name: img_n_optics
+    description: list of extra mirrors in METIS N imager
+    class: SurfaceList
+    kwargs:
+      filename: LIST_METIS_mirrors_img_n.dat
 
-    - name: filter_wheel
-      class: FilterWheel
-      description: IMG_N science filters
-      kwargs:
-          filter_names:
-              # 18 positions (E-REP-MPIA-MET-1008_1-0)
-              - open
-              - N1
-              - N2
-              - N3
-              - N_spec
-              - PAH_8.6
-              - PAH_8.6_ref
-              - PAH_11.25
-              - PAH_11.25_ref
-              - Ne_II
-              - Ne_II_ref
-              - S_IV
-              - S_IV_ref
-          filename_format: "!INST.filter_file_format"
-          current_filter: "!OBS.filter_name"
-          minimum_throughput: !!float 0.
-          outer: 56                        # E-REP-MPIA-MET-1008_1-0
-          outer_unit: "mm"
+  - name: filter_wheel
+    description: IMG_N science filters (E-REP-MPIA-MET-1008_1-0)
+    class: FilterWheel
+    kwargs:
+      filter_names:
+        # 18 positions (E-REP-MPIA-MET-1008_1-0)
+        - open
+        - N1
+        - N2
+        - N3
+        - N_spec
+        - PAH_8.6
+        - PAH_8.6_ref
+        - PAH_11.25
+        - PAH_11.25_ref
+        - Ne_II
+        - Ne_II_ref
+        - S_IV
+        - S_IV_ref
+      filename_format: "!INST.filter_file_format"
+      current_filter: "!OBS.filter_name"
+      minimum_throughput: !!float 0.
+      outer: 56                        # E-REP-MPIA-MET-1008_1-0
+      outer_unit: "mm"
 
-    - name: nd_filter_wheel
-      class: FilterWheel
-      description: IMG_N neutral density filters
-      kwargs:
-          filter_names:
-              # 11 positions (E-REP-MPIA-MET-1008_1-0)
-              # OD = optical density, transmissivity 10^{-OD}
-              - open
-              - ND_OD1
-              - ND_OD2
-              - ND_OD3
-              - ND_OD4
-          filename_format: "!INST.filter_file_format"
-          current_filter: "!OBS.nd_filter_name"
-          minimum_throughput: !!float 0.
-          outer: 56                  # E-REP-MPIA-MET-1008_1-0
-          outer_unit: "mm"
+  - name: nd_filter_wheel
+    class: FilterWheel
+    description: IMG_N neutral density filters (E-REP-MPIA-MET-1008_1-0)
+    kwargs:
+      filter_names:
+        # 11 positions (E-REP-MPIA-MET-1008_1-0)
+        # OD = optical density, transmissivity 10^{-OD}
+        - open
+        - ND_OD1
+        - ND_OD2
+        - ND_OD3
+        - ND_OD4
+      filename_format: "!INST.filter_file_format"
+      current_filter: "!OBS.nd_filter_name"
+      minimum_throughput: !!float 0.
+      outer: 56                  # E-REP-MPIA-MET-1008_1-0
+      outer_unit: "mm"
 
-    - name: metis_psf_img
-      descriptions: field constant, wavelength dependent PSF for imaging mode
-      class: FieldConstantPSF
-      kwargs:
-        filename: "!OBS.psf_file"
-        wave_key: "WAVELENG"
-        bkg_width: -1
+  - name: psf
+    description: field constant, wavelength dependent PSF for imaging mode
+    class: FieldConstantPSF
+    kwargs:
+      filename: "!OBS.psf_file"
+      wave_key: "WAVELENG"
+      bkg_width: -1
 
 ---
 ### default simulation parameters needed for a METIS simulation
@@ -83,5 +84,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 1E-3   # microns (spectral bin width)
-    spectral_resolution: 5000
+    spectral_bin_width: !!float 1E-3   # microns, defines fov wavelengths
+    spectral_resolution: 5000          # defines skycalc resolution

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -1,5 +1,6 @@
-# yaml extension for METIS long-slit spectroscopy
 ---
+## METIS long-slit spectroscopy
+
 object: instrument
 alias: INST
 name: METIS_LSS
@@ -9,22 +10,16 @@ changes:
   - 2022-01-12 (OC) changed spectral_resolution to _bin_width
 
 properties:
-    decouple_detector_from_sky_headers: True
+  decouple_detector_from_sky_headers: True  # needed for slit spectroscopy
 
 effects:
-  #  - name: lss_mode_optics
-  #    description: list of extra optical elements for LSS
-  #    class: SurfaceList
-  #    kwargs:
-  #      filename: LIST_METIS_mirrors_lss_lm.dat
-
   #  - name: blaze_function
   #    description: grating efficiency
   #    class: TERCurve
   #    kwargs:
   #      filename: TER_blaze_L.dat
 
-  - name: lss_spectral_traces
+  - name: spectral_traces
     description: list of spectral order trace geometry on the focal plane
     class: SpectralTraceList
     kwargs:
@@ -32,7 +27,6 @@ effects:
       wave_colname: "wavelength"
       s_colname: "xi"
       col_number_start: 1
-      decouple_sky_detector_headers: True
 
 ---
 ### default simulation parameters needed for a METIS simulation
@@ -43,5 +37,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 5E-4   # microns (spectral bin width)
-    spectral_resolution: 5000
+    spectral_bin_width: !!float 5E-4   # microns, defines fov wavelengths
+    spectral_resolution: 5000          # defines skycalc resolution

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -1,11 +1,11 @@
 ---
-### default observation parameters needed for a METIS simulation
+### default configuration for METIS simulations
 
 object: configuration
 alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
-date_modified: 2022-02-20
+date_modified: 2022-02-21
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
   - 2021-12-16 (OC) default slits renamed
@@ -13,6 +13,7 @@ changes:
   - 2022-01-10 (OC) adc defaults to false for N band
   - 2022-01-25 (OC, KL) add detector modes
   - 2022-02-20 (OC) pupil_transmission now an OBS parameter
+  - 2022-02-21 (OC) linear interpolation, cosmetics
 
 packages:
   - Armazones
@@ -91,7 +92,7 @@ mode_yamls:
   - object: observation
     alias: OBS
     name: lss_m
-    description: "METIS LM-band slit spectroscopy"
+    description: "METIS M-band slit spectroscopy"
     yamls:
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
@@ -166,7 +167,7 @@ properties:
     wave_max: 14.0
 
   computing:
-    spline_order: 3
+    spline_order: 1
     preload_field_of_views: True
 
 ---

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -5,13 +5,14 @@ object: configuration
 alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
-date_modified: 2022-01-25
+date_modified: 2022-02-20
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
   - 2021-12-16 (OC) default slits renamed
   - 2022-01-07 (OC) trace files default to science version
   - 2022-01-10 (OC) adc defaults to false for N band
   - 2022-01-25 (OC, KL) add detector modes
+  - 2022-02-20 (OC) pupil_transmission now an OBS parameter
 
 packages:
   - Armazones
@@ -33,6 +34,7 @@ properties:
   exptime: 1.
   dit: 1              # when exptime is given and auto_exposure is on,
   ndit: 1             # these values are ignored
+  pupil_transmission: 1.0
   auto_exposure:
     fill_frac: 0.75   # fraction to which full well is filled in one DIT
 

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -150,7 +150,7 @@ if __name__ == "__main__":
                 if "c" in arg:
                     kwargs["compile_pkg"] = True
                 if "u" in arg:
-                    kwargs["upload"] = True
+                    kwargs["upload_pkg"] = True
                 if "h" in arg:
                     print(HELPSTR)
             else:


### PR DESCRIPTION
The published packages should not contain crap like `__pycache__`, `.ipynb_checkpoints` and the like. As `shutil.make_archive` does not have the option to exclude stuff `shutil.copytree` is used to  copy the package to a temporary directory, ignoring a list of `ignore_patterns` before archiving. 
Also some pylint cosmetics. `compile` is a builtin and should not be used as a variable, changed to `compile_pkg` (and `upload_pkg` for symmetry). This does not affect the user interface. 