### PR TITLE
Rename ELT.telescope_reflection to just ELT.reflection.

### DIFF
--- a/ELT/ELT.yaml
+++ b/ELT/ELT.yaml
@@ -14,7 +14,7 @@ properties :
     filename : "TER_ELT_5_mirror.dat"
 
 effects :
-  - name : telescope_reflection
+  - name : reflection
     description : single combined reflection curve (ESO-333023)
     class : SurfaceList
     include : True


### PR DESCRIPTION
It is clear that `telescope_reflection` is the reflection of the telescope, because it is in a telescope object, so it is nicer to call it simply `reflection`.

(Ulterior motive: MicadoWISE models telescope objects with a Telescope Python class. It is much nicer to have a `Telescope.reflection` attribute than a `Telescope.telescope_reflection` attribute. These attributes automatically get converted to hierarchical FITS headers, taking the first three letters of the object, the effect, and then the kwarg. `TEL TEL FILENAME` is ugly, `TEL REF FILENAME` is a bit better.)

(I also plan to remove the `micado_` from many of the effect names in MICADO, because it is obvious they are for MICADO. But those don't require much consensus.)

@oczoske the `telescope_reflection` name is from you. Is it okay to change it to `reflection`?
