### PR TITLE
 Rename ELT.telescope_reflection to just ELT.reflection pt2

### DIFF
--- a/ELT/ELT.yaml
+++ b/ELT/ELT.yaml
@@ -14,7 +14,7 @@ properties :
     filename : "TER_ELT_5_mirror.dat"
 
 effects :
-  - name : telescope_reflection
+  - name : reflection
     description : single combined reflection curve (ESO-333023)
     class : SurfaceList
     include : True

--- a/METIS/tests/norun_test_ScopeSim_MET_IMG_LM.py
+++ b/METIS/tests/norun_test_ScopeSim_MET_IMG_LM.py
@@ -161,7 +161,7 @@ class TestSourceFlux:
         metis = sim.OpticalTrain(cmd)
 
         for eff in ["skycalc_atmosphere",   # Adds ~58000 ph/s/pix
-                    "telescope_reflection", # Adds ~20 ph/s/pix
+                    "reflection", # Adds ~20 ph/s/pix
                     "common_fore_optics",   # EntrWindow alone adds ~14700 ph/s/pix
                     #"metis_img_lm_mirror_list",           # Adds ~0 ph/s/pix
                     "quantum_efficiency",
@@ -199,7 +199,7 @@ class TestSourceFlux:
         metis["detector_linearity"].include = False
 
         # for eff in ["skycalc_atmosphere",  # Adds ~58000 ph/s/pix
-        #             "telescope_reflection",  # Adds ~20 ph/s/pix
+        #             "reflection",  # Adds ~20 ph/s/pix
         #             "common_fore_optice",  # EntrWindow alone adds ~14700 ph/s/pix
         #             "metis_img_lm_mirror_list",  # Adds ~0 ph/s/pix
         #             "quantum_efficiency",
@@ -230,7 +230,7 @@ class TestSourceFlux:
         cmd = sim.UserCommands(use_instrument="METIS", set_modes=["img_n"])
         metis = sim.OpticalTrain(cmd)
         for eff in ["skycalc_atmosphere",   # Adds ~58000 ph/s/pix
-                    "telescope_reflection", # Adds ~20 ph/s/pix
+                    "reflection", # Adds ~20 ph/s/pix
                     "common_fore_optics",   # EntrWindow alone adds ~14700 ph/s/pix
                     "chop_nod",
                     # "metis_img_lm_mirror_list",           # Adds ~0 ph/s/pix

--- a/METIS/tests/norun_test_ScopeSim_MET_LSS.py
+++ b/METIS/tests/norun_test_ScopeSim_MET_LSS.py
@@ -80,7 +80,7 @@ class TestMetisLss:
 
         toggle_effects = [
                           # "skycalc_atmosphere",
-                          # "telescope_reflection",
+                          # "reflection",
                           # "common_fore_optics",
                           # "metis_img_lm_mirror_list",
                           # "quantum_efficiency",
@@ -120,7 +120,7 @@ class TestMetisLss:
 
         toggle_effects = [
                           "skycalc_atmosphere",
-                          "telescope_reflection",
+                          "reflection",
                           "common_fore_optics",
                           # "metis_img_lm_mirror_list",
                           # "quantum_efficiency",


### PR DESCRIPTION
Same as #42  but then to the master branch. The branch structure of the IRDB is not clear to me.

It is clear that `telescope_reflection` is the reflection of the telescope, because it is in a telescope object, so it is nicer to call it simply `reflection`.

(Ulterior motive: MicadoWISE models telescope objects with a Telescope Python class. It is much nicer to have a `Telescope.reflection` attribute than a `Telescope.telescope_reflection` attribute. These attributes automatically get converted to hierarchical FITS headers, taking the first three letters of the object, the effect, and then the kwarg. `TEL TEL FILENAME` is ugly, `TEL REF FILENAME` is a bit better.)

(I also plan to remove the `micado_` from many of the effect names in MICADO, because it is obvious they are for MICADO. But those don't require much consensus.)

@oczoske the `telescope_reflection` name is from you. Is it okay to change it to `reflection`?
