### PR TITLE
Draft: Test to only count failure if the ScopeSIM branch is the same.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,11 @@ jobs:
             echo "Target IRDB branch: ${GITHUB_BASE_REF}"
             echo "This IRDB branch:   ${GITHUB_REF_NAME}"
             echo "ScopeSIM branch:    ${{ matrix.scopesim-branch }}"
-            this_branch_is_scopesim_branch=$(expr "${GITHUB_REF_NAME}O" == "${{ matrix.scopesim-branch }}O" )
+            this_branch_is_scopesim_branch=$(expr "${GITHUB_REF_NAME}O" == "${{ matrix.scopesim-branch }}O" || true )
             echo "this_branch_is_scopesim_branch: ${this_branch_is_scopesim_branch}"
-            target_branch_is_scopesim_branch=$(expr "${GITHUB_BASE_REF}O" == "${{ matrix.scopesim-branch }}O" )
+            target_branch_is_scopesim_branch=$(expr "${GITHUB_BASE_REF}O" == "${{ matrix.scopesim-branch }}O" || true )
             echo "target_branch_is_scopesim_branch: ${target_branch_is_scopesim_branch}"
-            not_running_as_pr=$(expr "${GITHUB_BASE_REF:+hello}O" != "helloO")
+            not_running_as_pr=$(expr "${GITHUB_BASE_REF:+hello}O" != "helloO" || true )
             echo "not_running_as_pr: ${not_running_as_pr}"
             if [[ this_branch_is_scopesim_branch -eq 1 || target_branch_is_scopesim_branch -eq 1 || not_running_as_pr -eq 1 ]] ; then
                 must_succeed="true"
@@ -59,8 +59,10 @@ jobs:
             echo "must_succeed: ${must_succeed}"
             echo "may_fail: ${may_fail}"
             #pytest irdb/tests/test_utils.py
+            set +e
             python -m pytest irdb/tests/test_utils.py
             result=$?
+            set -e
             if [[ ${may_fail} ]] ; then
                 echo "May fail, so exiting 0."
                 exit 0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,4 +36,7 @@ jobs:
           pip install git+https://github.com/AstarVienna/ScopeSim.git@${{ matrix.scopesim-branch }}
           pip install git+https://github.com/AstarVienna/ScopeSim_Templates.git
       - name: Run Pytest
-        run: pytest
+        # Allow failure if e.g. IRDB dev_master is ran against ScopeSIM master.
+        # A pytest failure is only counted if both branches are the same, that
+        # is both master or both dev_master.
+        run: pytest || [[ ${{ matrix.scopesim-branch }} != $GITHUB_REF_NAME ]]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,14 +40,14 @@ jobs:
         # A pytest failure is only counted if both branches are the same, that
         # is both master or both dev_master.
         run: |
-            echo "Target IRDB branch: ${pull_request_target}"
+            echo "Target IRDB branch: ${GITHUB_BASE_REF}"
             echo "This IRDB branch:   ${GITHUB_REF_NAME}"
             echo "ScopeSIM branch:    ${{ matrix.scopesim-branch }}"
             this_branch_is_scopesim_branch=$(expr "${GITHUB_REF_NAME}O" == "${{ matrix.scopesim-branch }}O" )
             echo "this_branch_is_scopesim_branch: ${this_branch_is_scopesim_branch}"
-            target_branch_is_scopesim_branch=$(expr "${pull_request_target}O" == "${{ matrix.scopesim-branch }}O" )
+            target_branch_is_scopesim_branch=$(expr "${GITHUB_BASE_REF}O" == "${{ matrix.scopesim-branch }}O" )
             echo "target_branch_is_scopesim_branch: ${target_branch_is_scopesim_branch}"
-            not_running_as_pr=$(expr "${pull_request_target:+hello}O" != "helloO")
+            not_running_as_pr=$(expr "${GITHUB_BASE_REF:+hello}O" != "helloO")
             echo "not_running_as_pr: ${not_running_as_pr}"
             if [[ this_branch_is_scopesim_branch -eq 1 || target_branch_is_scopesim_branch -eq 1 || not_running_as_pr -eq 1 ]] ; then
                 must_succeed="true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,32 @@ jobs:
         # Allow failure if e.g. IRDB dev_master is ran against ScopeSIM master.
         # A pytest failure is only counted if both branches are the same, that
         # is both master or both dev_master.
-        run: pytest || [[ ${{ matrix.scopesim-branch }} != $GITHUB_REF_NAME ]]
+        run: |
+            echo "Target IRDB branch: ${pull_request_target}"
+            echo "This IRDB branch:   ${GITHUB_REF_NAME}"
+            echo "ScopeSIM branch:    ${{ matrix.scopesim-branch }}"
+            this_branch_is_scopesim_branch=$(expr "${GITHUB_REF_NAME}O" == "${{ matrix.scopesim-branch }}O" )
+            echo "this_branch_is_scopesim_branch: ${this_branch_is_scopesim_branch}"
+            target_branch_is_scopesim_branch=$(expr "${pull_request_target}O" == "${{ matrix.scopesim-branch }}O" )
+            echo "target_branch_is_scopesim_branch: ${target_branch_is_scopesim_branch}"
+            not_running_as_pr=$(expr "${pull_request_target:+hello}O" != "helloO")
+            echo "not_running_as_pr: ${not_running_as_pr}"
+            if [[ this_branch_is_scopesim_branch -eq 1 || target_branch_is_scopesim_branch -eq 1 || not_running_as_pr -eq 1 ]] ; then
+                must_succeed="true"
+                may_fail=""
+            else
+                must_succeed=""
+                may_fail="true"
+            fi
+            echo "must_succeed: ${must_succeed}"
+            echo "may_fail: ${may_fail}"
+            #pytest irdb/tests/test_utils.py
+            python -m pytest irdb/tests/test_utils.py
+            result=$?
+            if [[ ${may_fail} ]] ; then
+                echo "May fail, so exiting 0."
+                exit 0
+            else
+                echo "Must succeed, so exiting ${result}."
+                exit $result
+            fi


### PR DESCRIPTION
DO NOT MERGE AS-IS

The goal of this PR is that, if you have a feature branch that you want to merge into dev_master, that then you want your tests to run against ScopeSIM dev_master. Those tests should all pass. However, it is very useful to know whether your tests would also pass against ScopeSIM master, but you don't want that to cause the CI to fail; you just want to know whether your new code works against the ScopeSIM master branch.

This MR ensures that you only get failing red checks when the test fails against the same branch of ScopeSIM. It will also run the tests against the ScopeSIM master branch, but those will always succeed when ran in a PR. However, when you run the CI outside of a PR, then all tests can become red.

What this does, is that if there is a bug, then
- The bug is ignored if we are testing IRDB dev_master against ScopeSIM master (or vice-versa) in a PR: the 3 greens in https://github.com/AstarVienna/irdb/runs/5840214584?check_suite_focus=true
- The bug in NOT ignored if we are testing against the same branch in both repositories, e.g. dev_master: the 3 reds in https://github.com/AstarVienna/irdb/runs/5840214584?check_suite_focus=true
- The CI is triggered outside a PR, e.g. manually, because that is an indication that you are interested in all problems: the 6 reds in https://github.com/AstarVienna/irdb/actions/runs/2098478168

NOTE: For ease of testing, this PR only runs pytest on one test
