### PR TITLE
Oc/update metis demo notebooks

### DIFF
--- a/METIS/docs/example_notebooks/demos/demo_adc_wheel.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_adc_wheel.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"]) "
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"]) "
    ]
   },
   {
@@ -176,7 +176,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -190,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_auto_exposure.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_auto_exposure.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -317,7 +317,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -331,7 +331,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_chopping_and_nodding.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_chopping_and_nodding.ipynb
@@ -11,34 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Python:\n",
-      " 3.6.8 (tags/v3.6.8:3c6b436a57, Dec 24 2018, 00:16:47) [MSC v.1916 64 bit (AMD64)]\n",
-      "\n",
-      "scopesim :  0.4.0\n",
-      "numpy :  1.19.5\n",
-      "scipy :  1.5.4\n",
-      "astropy :  4.1\n",
-      "matplotlib :  3.3.4\n",
-      "synphot :  1.0.1\n",
-      "skycalc_ipy : version number not available\n",
-      "requests :  2.25.1\n",
-      "bs4 :  4.9.3\n",
-      "yaml :  5.4.1\n",
-      "\n",
-      "Operating system:  Windows\n",
-      "         Release:  10\n",
-      "         Version:  10.0.19041\n",
-      "         Machine:  AMD64\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import scopesim as sim\n",
     "sim.bug_report()\n",
@@ -49,7 +24,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,16 +41,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,18 +76,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Chop offsets: [3, 0]\n",
-      "Nod offsets:  [0, 3]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"Chop offsets:\", sim.utils.from_currsys(metis['chop_nod'].meta['chop_offsets']))\n",
     "print(\"Nod offsets: \", sim.utils.from_currsys(metis['chop_nod'].meta['nod_offsets']))"
@@ -120,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,21 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requested exposure time: 1.000 s\n",
-      "Warning: The detector will be saturated!\n",
-      "Exposure parameters:\n",
-      "                DIT: 0.011 s  NDIT: 90\n",
-      "Total exposure time: 0.990 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "metis.observe(src, update=True)\n",
     "imghdu = metis.readout()[0][1]"
@@ -151,32 +105,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.colorbar.Colorbar at 0x2a7bcb20dd8>"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAATkAAAEDCAYAAABOAHM6AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABYeklEQVR4nO29ffCtV1Um+Kx7A1EDFqHppjGJEJnoFDrdEVNIjR+NYvM1ltGpGidUj0SlOloNjsxoOdD8oWUXNY7tRzfVNl1xjMIMA02LNKkZbAyMNmPZKIFGCCAkfDgkE0lhbIHExtx71/xx3hN31n2etdZ7zvv73fO7/a5bp8777o+119577Wc96z2/c4+5O1ZZZZVVLlY5daENWGWVVVY5SllBbpVVVrmoZQW5VVZZ5aKWFeRWWWWVi1pWkFtllVUuallBbpVVVrmoZQW5VVZZpSVmdouZ3WdmdzTa/qKZvX96fczM/sMxmMhtWf9ObpVVVumImX0rgC8AeJ27f92Mfj8C4Ovd/QePzLhEVia3yiqrtMTd3wXg/rHMzJ5qZv/GzN5rZv+Pmf3npOsLAbzhWIwkcsmFGniVVVa5KORmAD/s7nea2TcC+OcAvn1baWZPBnA1gP/7Atm3gtwqq6yym5jZYwD8lwD+lZltiy8NzW4A8OvufvY4bRtlBblVVlllVzkF4D+4+7VJmxsAvOR4zOGyPpNbZZVVdhJ3/xyAT5rZfwMAtpG/va2fns9dDuDfXSATAawgt8oqqzTFzN6ADWB9jZndbWYvBvD3ALzYzP4QwIcAXD90uQHAG/0C/wnH+ickq6yyykUtK5NbZZVVLmo5+A8eTj/mMr/k8Y/f3HRJp81om/XdXkd9rM32GqSu0mNDWdQF0YbdZ3aovmO70S5W17WX2cX2hPVR9rD9jPZ01ljtG1s7tcZsTkwH0zOWM/syUTYonQj3wq4z99+Ps194oGOBlOd+22X+p/f3PkB97we++HZ3f94+482Rgwe5Sx7/eHzF//iy8yuYM84BJKVvK8qBYlvlrApw2LjVgVI2MduUfXG8eN21bZcx1diZPqVX9Zt7RNlejWPOBbNsDOU7lS3Mr1W7zD+zYGLA//dz/0Q06Muf3n8Wf/D2r2y1Pf2kO5+w94AzpExXzewqM/ttM/uwmX3IzH50Kn+8md1mZndO75dP5WZmrzazu8zsA2b29EHXjVP7O83sxlmWGvhmGbnO2o3vsUw5WOVAHWevxId3ZhdzcGXbWK7Wgh2MLvAwfWqNRr0dxmI4v0+0qZqfi+uxjNmYzT+u2Xgd92HcryxIsH6sXayLfjfaxIINW8NR9uJwf6XyXPPfcUvnmdwZAD/m7k8D8EwALzGzpwF4OYB3uvs1AN453QPA8wFcM71uAvAaYAOKAH4SwDcCeAaAn9wCYyqZI2Xt2UHGUMdk25454Fgf9XTAwMAPU+bYsX9nrEx/5swROKIOBi4sUGzbdwBXzZ31ifcRpNh+jXWxLBM1dsY2FbAz3RnYZywsA9bKLrUPHT0NcTge8rOt13FLCXLufq+7v2+6/jyAjwC4ApuPil87NXstgO+erq/H5gu87u7vBvA4M3sSgOcCuM3d73f3PwNwG4D5eblyoGqzOnXK+RhbjPUMgBUjY/0Zw4z6I4uoQIMBfgbg0VZWz+q2ZeoAd0BX9WE65zDOKhhmezJeR4bdBZuxL2O1neClMo0scFbBImPCO8qhMrlZz+TM7CkAvh7A7wN4orvfO1X9CYAnTtdXAPj00O3uqUyVs3FuwoYF4vTlgeyxg8wiVhYBWfrUidbRBsUUY506oIqlRNuYTmWbKmM2Z2DJ1ii2Z8wvS69A2qk5ddhstv7K7tFfOpnBWFftdcWUY/uoY2yngI3ZE+fH9GZjLCAOx9kD/XO09p+QTN9TezOAl01/6fywTH/st9gM3f1md7/O3a87/ZjLBiPCO3M+ljpkhyzqjnoiA6ras7rteAz42EGLB0YdoKiTvSt2F/urQxL7zLEbOH8eFZtlh1KttWJ4ao/ZulTAFHVmNmVrEv0p84UqaGVzZuvIpMMgZ8o5eOt13NICOTN7FDYA93p3/42p+DNTGorp/b6p/B4AVw3dr5zKVHlfqoga26j0qUoNosMq4IxOzYBTHYrKoSvAUpFeMZbM+TNQqA5DXK9O2sXWJGOAChzj3KKubMzIVBWIsPXN9j5jyaxdBNxsLZkPRHuiPmYrY+l7igM4C2+9jls6n64agF8B8BF3/4Wh6lYAN07XNwJ461D+oulT1mcC+PMprX07gOeY2eXTBw7PmcpyiQ4wJyUYy5kzWahXbInVRwDLbGNMZ8484jisTTYH4HxnjzZkQBHHYLZmYB5tZgdNAVbUyQ5zFlwYa2PrGW2O7Sr2qVikYo3MB9Vc1H2ml/kHk/8EmFznmdw3Afg+AB80s/dPZf8QwM8AeNP0/bU/BvC9U93bALwAwF0AHgTwAwDg7veb2T8C8J6p3U+7+yP+Az4pMSrGA8Kil5JOipABXmRLUS+zIUZn5bjqQDCWoOxgwvQzyZjSeJ+xuq2eiqGO4yl2MbZnzIjZn4E82+OKRamyqKMKwGP/qIsFrnEcBaDVfmQ6WJs9xAE8dKDP5EqQc/ffhV6GZ5P2DvFfq7j7LQBumWNgyi7Gss6Gx36dzY2Hi/WLBya2r2zqHJKOc7LD1xk3i/IZk9i2Gd+3bRiDy8CrOuBxPAZ61foppq/6dZhcFBakmA1ZkMx0Zn06Ps3WbAFsclyYVLQjB/+Nh5Q1qDSEHQR26MY+auwYabNDz5yQHcYMKLN6NkYExw6LYuwkto11GYhl/WKdOqhZUOiscdRV7VXlD456jl1WlAGf8jG23mpd2XooHZX9u4oDZw8T404AyFURmEWzKCrdUO0Yi8gcLKYso0MygIvlnWjK5q3AW4F8HCurZ8wyYyLK1q10mVBHr2J52dqzawVuKrCpwBPbxXrlpwx0lU9U99m4zP5sn3cQBy7AX8D15PBBbpQOQ6n6qYg4tlNRfryPbKgaW4GvcsA4nkrN5jpodhhV2QjeFTNlwFGBbWw/XivGOZchK/uquTO9nTVcggUzBjeWZUw1tldjLMa+DGcXpYbLyckCOSAHFLaZHUfYts2cO3OU2J4dajZ+dsBYRO+Aeea08YBkTIYxH6U/CwhdgBvbM11xnIohq/2q1r8jGQPLJPMPxfaUDmZPBsaK1S0Ecg7gIV9BbjdRKcdYv5UsykV9CoS6Nm3H294rxgHStsvC1MFU6UgFxJ11UeMr0FFAWelnzDDuXdwjNhYT5TMd0GZzYgGw2kMFYNl4at5VAKpEAdxWFgA6B1Ymt7OwzQZ6EVSlLlEvG6vj/NW4KjJnwDSOFcfsALMaOwOLOcC8ve+kPF1mycZU1+ygM73sugqYzK4OiHfBh+2r8reMyY56mI9gqItjMPsWwqZzK5PbQ6JTxA3M6Hss67TLDmbFKmJ9lpqN9dkBVM5ZAQRz7tiWgSyzWx2ejP0p25iwdRvvWRu1T13GmjFIQO9dl0VWgKfus2DGgl5m9wiEc5j3TFmZ3FISD23lPGpzRx1ju8qpmF7WRqUbzAcqptb1G3Z4M/CNfWLddmwVABiLVgCs5q2YeMfW2HYO01PgPdqr5q3WTK1dxraUTVWWkAWXqEOB+oIAt1FjOHugv6ZwMkBOsZyMdbFDxOg78EhHrJgcRLuOLfE69mPzUlF6LO+wXMVkMyBW4wC7HY5sfeb0n8sSY5s5QaSzzwxERlHzq8A06mAMMQOtWK8AfSFZMl01s9MAbgdwj7t/5z66Dh/kVNTrsrPMMVg5QrkaMwMhpiNG9Qx8FdBEh2WpCgNuNh8m6qCM9XPATc1je69AWLFqhDbVmLG9ChDKB2JgUeMp0MvK2D3zzWwdqvUdyzP2uAA2OQx/6af3V/RX8qPY/N+VX76vosPkl1GUg4wHWUVAVTbqYYe6q0cdyAgOVXrQOWyVPYZHrklXukDN7rMyx/l7w+yKbTP2iaFNlrKxviy4qLkaqR/HYP2iL8Z6ZbcSFRiiLeyezW0XBtwUB3AOp1qvSszsSgD/FYD/dQnbDp/JAZxFZRuUsbIOeGTtMrBiIKVSUQZqKu1Qc1UsjtnNxoi6M5tHHWzcCKxzGGC2nxlTyg48s2GX8Vl/BcJKD9sHpTvruysbV/oWlhkfPDzBzG4f7m9295uH+38C4CcAPHYJuw4f5BS7YWUxDWHtKiaB0C5jCx07M5YT22TMZVuvwEQBbJbCQNwz3RnDVeUs9VJg3gFKJnNZK7O1s+5V284YLAhF3XNSSOY3md+yoLWQuBvOejsx/Ky7X8cqzOw7Adzn7u81s2ctYdvhg9xW2OHogkl2EFRUVQdfMbzMgePhVoCRRfjI/qJe1qd7IDOdGZMaJWNSKshU6zGOnwG2simWzznUTO+c4KAAi7HpqGsO6FY+0JnHQnJuGaXfBOC7zOwFAL4EwJeb2f/u7v/drgpPBshlaRY7NPFgZOmOSsGiPoT6zCGzgxxFOT1EeedgKQaVMaXRHmVbNRelJ+rLxu6OwdaN7U1kwR2pGL1az7F9JysYRc2DgZfKArKzEPspfTvK5oOH/eHE3V8B4BUAMDG5H98H4ICTAnJZ1K42qirPAFT1rw5hBSbRZgVk0ZnVgapYw6hT1StRAFf1rdI1ZgdjftGGXUSBf9Z+tEMFtso31BpVrGqOncq3qoykqpspDrQ+VLgQcjJArnI6dl8ByT6Hfc7hVmOoa8W4GBCOdqn5Mtaa2ZWVdw5sV7fSN+rKWC5rP46p9lvtg2Keqi62q7KGzMYsmGV70wngnXktBHRnF/5al7v/DoDf2VfPyQC5rWSpoYr8jK5nhyfbpywVZOxDpa3MuTI7x7JoZ+boWZsKfJiNHZBmogCajbu9zw5xBVSKxbB96wS4bJwYPDJ9GcuLc+4GI6V7tFn52b4M+RHDHO43Hjo/ZHOLmd1nZncMZf/SzN4/vT61/e0HM3uKmf3FUPcvhj7fYGYfNLO7zOzV0w/kzBPmBDFaxcORAZwCkNg3XrNDG+1h7CzazfQxAOi2jW0Ue1O6Vftq7qx8W1cdegYUUZ8CPMaIKqa9iyhm5KJstI3ZlbHqan87fsT8WpUtuFbn/FTrddzSYXK/BuCfAXjdtsDd/9vttZn9PIA/H9p/3N2vJXpeA+DvY/PD1G8D8DwAvznbYhblGZOq0p2MTVRpFhsjK++mXCqy7hLdqyidsZns8DL9XZaR2cSYUMVOOoyQyRwWmu1hFjziu5p/ZWMG/Azo2Hhj2RGJAwfL5Do/ZPMuM3sKq5vY2PcC+PZMx/S7rF/u7u+e7l8H4LvRAbkx6imq3QURpX9876QdVfrXYTUq+rM+Sg9Lz1Q/xZiqVCsDsblpntIxZ+9YcIu6suAGnH/4s7EylsbAS1139Hf6qcC0tavSH9stBHwOw0PLfq1rMdkXer8FwGfc/c6h7Goz+/dm9m/N7FumsisA3D20uXsqo2JmN5nZ7WZ2+9kHHtgUjuytcp6xzXi4FRAx52ApCrMhtlG2qahbSWRVCuBGOyLbjXZXjs3AY059tL+qY0A1jpUx3AzIMr27CNtnFTziHqh9GmWXdVQ6lN+O9xXjnSHuwFk/1Xodt+z7wcMLAbxhuL8XwFe6+5+a2TcA+Ndm9rVzlU5f8bgZAC696ipP0805NFwBg7qeG+UU08zajZKlRCwFHnVV6RxjeyDXqo1qO+rvHkSmi11XTKRiZBnT6kjF0FhbJSrARlBiASkyNwXejAVGZlsFrJ3Flvpj4MVlZ5Azs0sA/NcAvmFb5u5fBPDF6fq9ZvZxAF8N4B4AVw7dr5zKGgORsoymZ5EV4JutnIY5TCf1ioeURU0GQjHiMvsYeLJDE9OpLoBm+jPArg7KnIOUpVPqUGYgtA9jUeCQtWd2Kb3R7oqpxzEqAhDbZedgD3HggrC0juxj1XcA+CN3fzgNNbO/Pv0/UDCzrwJwDYBPuPu9AD5nZs+cnuO9CMBbdxo1Yx0juFXOMZazaBcPrgIKZgcDk2hT5qjZIY9t4vzHsVR6F+s74B3tZelWJSxlY/cViMUyBrQxsMQ5doB51B31RH9j+jrrw5i/2n/l32o8tv+MACwkZ3Gq9Tpu6fwJyRsA/DsAX2Nmd5vZi6eqG/DIVBUAvhXAB6Y/Kfl1AD/s7vdPdf8Am/865S4AH8cun6w+bBT4Yd3WRckYUgVkFXjFOuZo6vBFHXHMONbYV0X+ivnEA145fbaeXaBgrFoFqwgkGTB2RTG5XUBovDbwfWegOr5nY1U+xnyuCoRK30IsbqPOcM57r+OWzqerLxTl30/K3gzgzaL97QC+bqZ950vFyrZ12aFijptFyFFHlmJk/TL9IxuoUhKWdow6QMpZ+zgnpr9zEOakPOywMzBgwKFY2bZOsdHsTHUYjWJYbGxVX+lXbbLgGRkmwn3mF3P2rCkO4KEFvrt6FHKYVjGJAJA5Vmw/inKASl/Uy5wlY4AxtWGMbw6zyOoYwDNg6a5pxhi6hyYDHsWIWRBRgaUDFJUdmWQAlvmCCrYssOwqivlX4y8KdOuPSy8jLHrP6aPSpDmHIIuKGUtioMZsVc7Xcc4sDVTt4/VcHZV0/V7NfS6oxTGzvekGNaWb2ZmVM4DLZA7LzGxRmcKCmOTABfk2Q0cOH+Q6h1uleVth0UwBG+vD7BnbZLqUk1c2R3szW2NdBoKqTxxLrfcuIKjmzWxjLFkFi27AyYJPJapdBlwjMGf9MvuXYHcV2C8sK5PbR9SzB4Ty8T6maNt+zDlZyqYOO3Oc6iAwm7MyNs8OE4xjq3XLGECln6199+DsesAylhnbqHGyFH0XiUDGgDgyqCxFVYyfjcvGYNfje6ZrAXG3lcntLcxZVPTLAEWxBOUU0VEVwFagMLZTUTYexOrgZsJAOuqvAKvDNOfY1QVEBgYq6Ki5MH37EI24Z4yFVf0Ue5srLOCNKX22fsD5PrGAOHCwX+s6GSDXTVUBvqkMqBSwKYfMgI71zRx6l1R5Too7ilqHikVm9kWb5owfy7JD1mHIUV9lS8amMqnsVIDFfGjO+BGMKj9m9WzsxWXWbzwcqxw+yClwUalWFlHZu3LQLKVjjqQYR8YS4zgKBBaKttS+aEccf6zP0tu5wh4LzG3fYW9V2b6yCyOa2zaC2DhutCMD0blrPkMcy/649JJy+CCnAEKBR5amVVFubrTLQHerd3zftstAFTjfmTtp6xzbmS/OYWT7Ctub7RgdZlfZclxnba7PLJWedn2no2tBObH/1dIFl4qZbdtkzG5OisDAJerqpnAqrVB2KolscewXx2T3asyOzNXdEZY2d4Fu1NEd56iEBTFWr+6jZI8LtvuvAiDLKFQwU332kO03Hg5RDh/kdpUqHZu7H+zZSteJs1R4POzq0GRAedR+tWSKmumZw+iU7LvHu8pRjRUzhV0Y+NhXpb0L7en6Qza7yi70u3rYqtJW9fwt1u2SXrGIqcCSRe9YHu1XutX9oYmyLXsMENvEdTsuYfbsA9Kxfzf7iOOPvpFlOkswOQceOreC3G7CWM+4cR1mo1idet5X2aH0RlGgFO1kgBv7j2VZ2hvb7wJuhwCI2bPHrOxC2w3MA43skUY1V3bfeTRTBfcdZJOuriC3m8RD3TnAVZRS4DEKi6SM9md6MgdUbbZlWeTd3ndSmF0c+LiBYg5IzWH2x5myzhH2aELZqZ7BbfvMASv2aGRBWb/xsKtkdJodfFUf26g+2cPaOcxt7FcxL2WPcsrIEDuSMYYLLXNsmXOODvHMZaAF8H1WjyTG9plPqD1fEOwc65+Q7C4jk8s2NEs9WaoYHUexs8iKFFNQABfHUzZlqW2UKlWvnm8dItB1hbHnkyQqQ2BlkbUzHWNZJ0OJ5YsB3ZquLiOKqUWpIiUDvezZX2VH1D3aEPtVDsrAWgE0s0cB2L5M8NAk7tNJFhZoMzDMwCzWqfT2CILFRfcbD8cm1TML1jbed+g+K2dAkT0fZMIOoQKysYyNFSN6B6AU6ztJ4JYdysM8V33JGH72fNFJW5VZsL1WLHFH2Xy6epjfXe389+e3mNl9ZnbHUPZTZnaPmb1/er1gqHuFmd1lZh81s+cO5c+byu4ys5e3LVSbe56hpF/nOQVrn7Gg7b1iUtF5FBBmc4r2jrpUeqyCwdjvpAJC3McqBbuQMsc25h+ZX0SfrrKMKmvI9MyUQ/7vzztJ9K9h82v3UX7R3a+dXm8DADN7Gja//fC1U59/bmanpx+3+SUAzwfwNAAvnNrOlw7gjW2r9HF8Z/07zzdGW6ITzmVfmQ+oZzPVmkTbTppUzxpjuwspWWawFRYAY12mTwVhw/k+oYLnEfjCOVjrddzS+Y2Hd5nZU5r6rgfwxumnCT9pZncBeMZUd5e7fwIAzOyNU9sPlxoV3Y7PFhRr6qSoGdNTDqVShey5SdZ/HLeyTdk5zlmNz1KaQxfGyOM8DgHglDBbWeCLTL0CzOr5mnpEcQRr5TjcT1f3+TjkpWb2gSmdvXwquwLAp4c2d09lqpyKmd1kZreb2e1nv/DA+YxKPYj18EKoZ8LYlwKByMzigWN6Mjs6wFg5pgLoeM/W5AhSWPPNa1mlM+/3Geeoz2kn6DK2pR45sH1kjzdGPcx/F5Bzfqr1Om7ZdcTXAHgqgGsB3Avg55cyCADc/WZ3v87drzt92WXnH3RF5zP29ogBiI7sWVomCnxVpN6VYXUcMQMuFigWTGEfBrdzBjtrDwPdzoDHgP6oUq1pbfyUw0/78kBXPYLYtlFZQ6W36qfWssoSZoi74Yyfar2OW3b6dNXdP7O9NrNfBvB/Trf3ALhqaHrlVIakvDnocF2lsOyepQRqjJj+ZYyN2RfrKumkJUyqZzdKz8IgYQ64Aaf/o+FRn98A3JkvA85ctsdAikWzFJ/1nRmkzn3JOZx6zEMwA84+cAlOPXia27GPdO1iKWsnfe2Md1QsGBdZumpmTxpuvwfA9pPXWwHcYGaXmtnVAK4B8AcA3gPgGjO72swejc2HE7fuZHGWAmbUPLIslb5l447jRVbE+mZpZHRgxixj2lEB9L5guKO4AXYOuORBw5X/8+/hip/5PTzqCwY7Y1jc79U+7TrHCaDty87g49/+q7jr234Vpy87s2F0R512j2VZgN626z52yc4H85MF9mj7TO4QP10tmZyZvQHAswA8wczuBvCTAJ5lZtdiM7dPAfghAHD3D5nZm7D5QOEMgJe4+9lJz0sBvB3AaQC3uPuHWhaOB76zPpVzdO5HXdEWxQ6ZA0b2Meof6yrgVk6ZgZpaA9VnidTFgEuuvAJn7r4HfgqLHJ6t3ke8dxjKXHHg3jNfwJMueQx8wTR+qzsF5ugD0eezzKHziIbpqXx3B1kCwMzsKgCvA/BEbCy72d3/6T46O5+uvpAU/0rS/lUAXkXK3wbgbbOse7gzNDhVoJX1iUAAch9TVaaX2RGfj3UBOtoZbYpglR0CNr9O2j9TzAE/BZz5Mscnv//JgD8ZZ79083xrm8ruJYzlxrpdx5hY6LkHL8E3/fZ/DxjgD16CU+ds9/XJQE3tbQbc2b535s+CBCvfQxb8TzPPAPgxd3+fmT0WwHvN7DZ3r/8SQ8jhf+NBPQ9T0YmldAr4WCobnVCxoDkgW4EWc3hlv5oLO5CRdUbGoILBTHHbAN3ZSx3nHuUP27NYZpLNbSEAPfUfT8H/8tGb632ZnAo2GbBloBjrqz5ju+1cMr9eSJb4Gzh3vxebDzPh7p83s49g85cYFzHIRUdWqaICrk46yjY7SxWYZA4UnYzZo+ZVpWpz0+Q4LrNpB/Fg56KPXhQYq7VSTKoQy/xhV2H73U0xx/duhjLeZ/NYGODcgTML/6eZ09/nfj2A399Hz+GDXNysOQcyRvsxqgHnA0s2RpZOZBIBmunN+mapKKtjNmXjLglGWBjctqL2aayr1qAjCx/8h3XOsUftdyxjfcY2WaDN+u8hM9LVJ5jZ7cP9ze5+89jAzB4D4M0AXubun9vHrsMHuSzFYm3ZZnZAMgO2jIFlTsnSYWYrszOO3wGlmLJ3WNpRHOwlpDqkRwGmRyEZA1dzYI8YxvssKFfsv+sXM2XmM7nPuvt1qtLMHoUNwL3e3X9jX9sOH+QADTbdlJVJd5OZ84yMkD1niePEcsY+1FyYrZXT7piuHZRUwSy2OfT5KuBS7bbXo190MokM2NQYC62dL/PpqmHzweZH3P0X9laI/b7WdXySPcdSG8bSFwYE2TMSVpcBaPfQjTZU4BftYTrY2NHJDx0EMlHgHffvJIjymw6ob9vGYDvWjX0ydjdeL5WuYpEv6H8TgO8D8O3sfznaRU4GkwM4wwHOB52MxXTbVg99s1RTpcpZmlCl4tGxM+fMUnXV5tCFHdiTzla782AANycDYTq2ZQuuofsyfyfn7r+LhXf28EFOAQB7PqMOQgV8qs0IrMxROm1B7qs5KCBUrIWl8JmcJIBTcpKBTj1uYG1iuqoCXuyryhiTW0QMZ9efJNxDGItSbIj1VdFQPetSjhMdM9qVgaJyYuCRThvrKlYW5zTqY3LSWByg7T2JAAf0HmVsr7ssb7xXe1wF6j1liWdyRyEnA+SA+jlV9XyhAxZjfQQNxiTH9gwgs9R0vJ7jcIr9qRQ5a7eLnESQPDRhzxazALvto/RUwHgM++U43C/onxyQqx6qqvrYl+lkzEmxoixdUCmBeg7C2mdpc1U21o36T2pat7QcyjrsYkMGXOoRxtgue8yxxJr45rncIcrhg5w68Oo5VGQvY30GOF07dom66nlblT6oiD+2VwDZTeej7oqpHYcjKxbNHgdkAUSlcwse7MX0VLq7c4764pox311oT9df69pH5qZIKsqpQ9B9KKvAjQEEA9HqWV+3TdZ2236u7JI67yoVM+2uCdPbHX9XYc9SWd0uATTqZo8lOix/LHdyrcbfQxzrBw+7i4rcEGXbcrWhEaiq5xlZG8aWKidnujIbssOinr/s+9ysOjj7SpV6Z4dO2aD8Ymn2lgFbBcxzdTOgiu3m7McRE601Xd1HGM1mlDz26ere6mNppUp5unqjvo4elqoBef8MfJcQlUIuIZ11yZ4tsbbdQLGvKPBZYmy196NeBniZb0RdC67L+unqUQs7eIr+Z+lpBKQIHipyZ4deARxLR2KbCLZsHh0bmC1qzsrucZwu0KnnRhU4sPEqu2Kfbdt92VxlpwpoLChnWQbTG/tlj1myzIa1d9J2R3FfQW4/qdLC7FlD9qxpDjuI7dRhzVhgNa4C1w7gdUTZWs2/SruzcTJAnnMmFNPu9NvatOsZnNtPpfq7js18fO5jiqN8/DDJ+ick+0pFwcdy1lcBUdRVOQqLmnOicpaCjnpjPWOPc8bLmFqVFmeHljEL1n+XVDpLyVgwmXtg5zBJ1U6xTOUfu6bSLBvI7OoE2oUx6VCfyZUfh0y/q3qfmd0xlP1jM/uj6XdX32Jmj5vKn2JmfzF8sfZfDH2+wcw+aGZ3mdmrp/9toC+KWmfRreOUY/n4PvZnrC0bMwLGaHusy+xn4jhfpxKVJo/sINrExhuBZns9J9WJB9LA1zKOO16P46k1y/Y/858sqLEUj43BAmYH0DoAHeeowL2bpm6vFwQlh+HcuVOt13FLZ8RfA/C8UHYbgK9z978F4GMAXjHUfdzdr51ePzyUvwbA38fmF7yuITp7wqI7c4Jt21iuDn5sn+ljqZdyGJUmqYPOHFWlLGq8aBNbq7ngytrFsdRhzNYmSgUqamymk60XW5dsHzr7H4UFxZF5xgCjWHQWUEegq/ZF1S0sMf6q13FLCXLu/i4A94ey33L3M9Ptu7H5HVUp008Yfrm7v9vdHZtf4/nuWZZmYJSBU4cxZHQ/251OpM8OoOqr3pn+Kr1lwmwc1wvkPdPD+kW9HYnzjewx7idjM0rnHGFryFjZ+IrzV/tQrQ8LaJW/Rz0qwMX+c/amEgfcrfU6blmCO/4ggN8c7q82s39vZv/WzL5lKrsCwN1Dm7unMipmdpOZ3W5mt5994AF98BTwjNfMOR8eCOenUtQgPNIhOswx2sRSNoh3xTCiHWN57BvtZMDA7KyAtRuOu21UEOmMk7F51Z6BAQNXtvaKZTNgU2sfbaz8NdaN93POw1yf3UUOlMrt9cGDmb0Sm58Qe/1UdC+Ar3T3PzWzbwDwr83sa+fqnf6/95sB4NKvvMrP21DmCJUDxDbnTSboZ7pHx2COzGyqUjamb+zH5svGUusSy9W9YpxR1AGM6RMDyWr9WTCI/TIm1GUo2TqpNR/bRDuY/mivWpPRnhiIsoCERv1oQ4f17ikX3Z+QmNn3A/hOAM+eUlC4+xcBfHG6fq+ZfRzAVwO4B49Maa+cypqD4XxH2Ipyui7FVwxn1MucL9PJ9AHcydR1HJvpUeXZuKxvtCuuKQORjJWya9Z3vFcMUrGieK/mrgJE5h8ZKLO1iONkDFr1U6yRlWcAqIKh2o+FxAGcO3eYILdTumpmzwPwEwC+y90fHMr/upmdnq6/CpsPGD4x/Zbi58zsmdOnqi8C8NZ5g+L8jY0bGh0qS2GqjY6Ht2IVisGowz32YXbGvqN0HVSBVjbWaJeyN2ujRPm/6l8Br2pXjcuAhrXJ7M0Ya3xFGxUIxTHU2Op+XCe2Vh3f20ccgFvvdcxSMjkzewOAZ2HzM2J3A/hJbD5NvRTAbdNfgrx7+iT1WwH8tJk9BOAcgB929+2HFv8Am09qvxSbZ3jjc7xcImixyBfb0skM9Z2IrnRm+6SiaxWpq4PFDmclMTAwlqTaqjI2RibdlEr1G0GFjdlZk4oNZ+yQAVXso9jYtk75lLItk2otGfCycSv7dpBD/Tu5EuTc/YWk+FdE2zdj81NirO52AF83y7rzlEADHbvOHDm2q8BtzmFSDEHZkgGM6t8BoGiDAne1pmNdxUqy8VmQGnUqqfZnDnhWhz8bX9nCglU2/i7CWHzcr5hpsD2LwaITXOfKSQW5Cy7xUGbPGWKfKFVaqA6BcrTINtj4KrUZx1CgF+87jKySKsVk4MkAfg6bimvRDUKsbs5cs7Wv1qHSyUBD+SlQr1E13lbi/ii2Wa3trvOXcmH+PKQjhw9y7IBXm8rAoLPpY92cNCyzUdlXMcs4focRzU1jO8Ggo3fuuGOfuSDdaZ8Fq13TxEp/FsQUg95lvCqYs6A79jvCdHVlcrvK3EMwSsYsMpBRY7PUII6l0sEM6FT6VkXxOLbqx0TVZ313ZVRs3LiWUWfF7LLxs/1dnMEMuqu6TkqrwGnbPzJFBqTKn8Z2MRvZVxzwA/109fBBDqgP9hzWtb3vSAY+VRvVfrxnzKJiBGoex+FfS46hGMj2OgOjzI5O4DgKUYFv6fEUk6vWiq3tUgBHjTscORkgB+hNVM93qnQophDKYTJHyCIvY3PMdsbCsj5jv12AO5PFnb7Qnz1mYCn72C9Kto5LSAVYu6aBnRS6Au5RTzcgr+nqAUsFHowZbe9VXwYWiv2psirVBGkzSjWPUSebkwJRprtrw9LSfdbXYWqq/EKko7u0A/Ig2XmcouqUXrVGS+37CnI7SjzUKr1jz7gwtI1gUEU41SZeZ5Ewe77C2mXOWbHRzN65YHfI0mVUhywKcFQKXzH2OYCVjbePOHAh/tC3I4cPcqNkz6sq5tUBjyrFVSywwyKy/VfPSDpzivPozueoU9NVuGTsvrO/URiDM5zf7xjA/8T+MfBBiQKuCBLZMwvWb2wzjtV95qWehzAGypxvdMoIWBmIq+d/zL5O2aFLlZKdBGHAw4KRCnyZf49jxDHV+Euu4/rp6o6SpXxsszKmF9sCPVBkdaP+yKLY87RRJ2sX03LVZxTFRFm7aMdJlE6gOmnSeVTS9VkGWsyXjsgf7ED34fBBLtvQTr8q8mXP01TaUEVKZkPUyWxh5VnKkoFapvMkS3aIT4pEP2IBWM1T+QRjgSo1rlLgXYSB54HI4YMck4whqfQzKxvLO0Cm+nXAL7OPscIK6JTuUd9JBrYM3A/0ULVkFz9T7C4DOkCDXTXmLDGsHzzsKtmG7MNWKlbFHDADUXXwlNONz1vic7muVOzuMH2uloqVnGRw20r3cUhWXqWias2qzGJXOdB9OXyQ20r1/C1jPupZWcWMsvIOw1J9OqlEZgtbA6V7aUe+EFIB3El5Lpex/pi+RkaPoS7qYvpjndKx5LqdW1DXgnL4IFcxlYzNsDSWUfhq0ytnqKJy1lcBZeboal5zwUylM/vIEqlk1JEx7gWfBW0fnO+UdXUAY04wHN+zxzPqkUeH0S0pjoNNV4//RxB3kZGlZICknnvF++wgZoAZnUo992DOlzFLpitz9OjImW8x1qvY5D4y2eynHX6Ja4DuClurmNYvCG7mgJ012Bl7GOxmfVpYte0Ad9QV/X37rrKZuf5f2TFTHl7H4lXqMXuemX10+o3ml+9r1+EzOQZq6pnN3MM+1kHUMRtUisscSjGuUU+lE6KeOWsHvJZ28knHuS85h9OPfQinTp3DQw88Cqe+cATutTA4bw/d6b8wPOoLBjsHPPQY4Mxlx5T/KgbYeRQyth31sbosrV1KFtA3/XzCLwH4u9j8qt97zOxWd//wrjpbTM7MbjGz+8zsjqHs8WZ2m5ndOb1fPpWbmb16QuEPmNnThz43Tu3vNLMbZ1nKDnwEOoRyFgWZ3jnAx1hl5mSM4cVIzBwzguBYF+ebjR/HPYqz65tMxb70DO76tl/Fx/7Oa/Goyx7aMLpdx2Op+xwG3hSf1uX0Xxiu+Jnfw1f87O/hkgcNdtaWzb46WYfqowL9tgzkOjJflonEPochzwBwl7t/wt3/EsAbAVy/j8JuuvprOP8X718O4J3ufg2Ad073APB8bH7A5hoANwF4DbABRWx+H+IbsZnIT26BsZQuO4ngA2iniBvOxmBpI6sfQSTa3UkpRn1xXMb4oq3MudW9Aoo9AdAcgBv+rwe/BABwzm05QK1SvSUOrgGXXLn5KeC9fm+lYtxjmbKblbP9iVkMq9+Kh1fl2zvIjHT1CdvfVZ5eNw1qrgDw6eE+/Y3mjrTyCXd/l5k9JRRfD+BZ0/VrAfwOgP9pKn/d9DOF7zazx5nZk6a2t21/2MbMbsMGON+QDs6cQYFefH4T2zNGUPWJelVazAAoc7wKvCoQZKLYHbuvDuOctHCy3R88jR/53b+HHzGH/8UlOHXWdDq2lCi22+3ugJ/apKef/IEnA/5knPkyB075pm4uAKjUc2trZacKlmosZV/HjzpssiuOOV/r+qy7X7fAqC3Z56HJE6efGgSAPwHwxOlaIfF+CK0oe/V8QTGeUVfFnGJ7dZ+NP0bQrt0sNWXziHoiWClhQL6LTHpOffEU8Jen4AacOqrUmKX7Y3m8LmQLYmcvdZx71KaTH8XHcZl9FVPLRLFbVc7sWkqW2e97AFw13M/7jWYii2znxNoWc2kzu2lLZc9+4YE+C2EHVqVvmRNk0XgcawTIOcASr1X0ZoeBjeOhXvXpMMCx3xwZdNhRAdzDA2D+/nX1LnnolUTbM3v3SZszljuHqXeH7KermbwHwDVmdrWZPRrADQBu3ceufUDuM1Maiun9vqlcIXEbod39Zne/zt2vO/2YyzaFWZoYgYsdgHjwKgfL0l3VT6UZimVFAGKsUaXriuXFMVjbHRhPW44C4BSgZY8FdhnGdkhPK2H+0s0+xr1jbViAHfsxfdGPAa5/F4lnUb0yFe5nALwUwNsBfATAm9z9Q/uYtQ/I3Qrgxun6RgBvHcpfNH3K+kwAfz6ltW8H8Bwzu3z6wOE5U1kuapPZJirKPoo6KKwdY0WVHRG4KoaWbX4n1d5FFNAeqsRD31m7Q5HKfxDqs2dyzK9YIB37VYF3ybVbAOQAwN3f5u5f7e5PdfdX7WtW65mcmb0BwLOw+VTkbmw+Jf0ZAG8ysxcD+GMA3zs1fxuAFwC4C8CDAH5gMvx+M/tH2NBRAPjp7YcQ+eDTu4o+MdpVQKfYVcbMYuRlaWN2r1igiqxZKpHNldk+ilrLkyRHwT6PU5j94zO5CHRZUM4yl/Fe+bGyZwfp/qHvhZDup6svFFXPJm0dwEuEnlsA3NK27uGO5D5uDju4bDPje6zv2BDTvc5zodiWAU4nde5KprMLqIcmc/fs0CSCWPbMbAQ+JRnri2MqXUvu//qfZu4oDJC2kgEFAzx2uCtmx1gTo/zVMw4FuFnUzuxRktnCdBymXz5SuoHkJAgDtFEyttVheDHDGXVlzwcXkENlcof/3VX10DXeZyDSZUpzgSpLkbPIqcZljhnTcaU76lVOfhJALcpJA+VKot9Uj1hY28yXY8agHu3MeE7WEm++jlkOn8mNwkCh83yqo6+z+GwsxZQqfSyFqBhrvN6OycBrDvtb5XilSjGzNLarJ8uAOpnHXDnpz+QuuLDnFBHo1GFH0n7UmaV1LF3KnmWoza4eDGdtWF1Wpg7ACniHIxVwRX/PUtYsJT0uWUFuD2GbPdaN77GPeu4158G/Sic6zK0CWGYv6xvHjuNmjHYFuI10GftxS/U8eayr7O+wuSx47yF2oP9p5uE/k9uKYm5Rdnkexdpkzy1UesjqWHn2DC72U8/mYlvWTtnEpHuIjkNUmsbWQK13pXeOHHdwUD4X37OgPAb3zjO/i1gOn8mNmx03ltF4RuGjPnYoGNBlzsDSXcUyY3uENl0Gmemp+lWyz7PNpYXt81g3vsc+R5G2dXWwxyBz9Cv/icEwAh0LYiyDGMfqZDBz5UDB8/BBbgSP7rOxCDrVM7dxLMWoYt9Yx/opQGXjVc9XWNvO4d9H1HhLjJEx8V36ATnDH+uXFAZEwG7jzO0T20c/YWvB7F1oP9cPHvaVGKm3ZYAGpmyTY33GwpQ9Sid7z6Jqds/mqJw7XivpPotRa7WE7KOrArKxXey3tFTMbSlgVeAUzwTrA9JGgfM+soLcjtJZuMzBoh5G25kelo6ySFnZpcbIUrLMrg5byWSOIy4NbJm+XdayErXWRyFVBrCPXpaWdteLlY/ZDUt1d5UV5PYQlvYxut0FO/UMgwGhYmZMvzrEFTCxtEEB7thnjnNWqYlK6Ud7lpBqHCaMZXdTrWw/dpWsPwtec+fL2nbnzFLVESjj9VybhBhwsJ+ungyQY8+b1POcCChxYxUgVc4Zx2G6GJip+zmgFx10F+muV9Un2thtP7aZy66yNJ7Vd2QuM1R2K7/JWPpcqVLiypZowxGl7Yf6TO7k/AnJVuJmsWcK6pkWi2ZRpwIDtoEqBWa2Vodj7JOl1JmdsU/HsSuAY0w2suG5KQ8LWp22Cug7z5d2SctYOlexq4rlZWN1RTF8lqVkjHzJVHU7Vud1zHL4TC46UhXNum3Hw1KlmF1HYAcxMqWKHTG2qg51pScD74pxbstUXceWTKeSaFN1oDvC1n8XFlkxtMj21Fi7pstV0GSigtWS4LaVA2Vyhw9yii1F8MvShPgMQjE6NT4DmQwkFBuMNikA7wJrxiQ7IKZ0dsB/rnT6ZAxkLGe+wA7zHMaoxmLXbF3ngPdYplh6xgaj76ozMdoYpWv3DDnUdPXwQY4d4CxSRiakKDJLY0dhIBEli6wVe8gOIWMDqh+bX2YLE1Wvon7FClk7Bkxj3132qGLgURTDnnM4s3Ua9Y7litFlAVlJ1q7aL7XGS7G6FeR2lMoRqwOsaL0CBsWAsn5qvAp8QdpVZRWrjKCXMTp1yNi9alMdkixt6wQYBkzRLtYu2sz6ML1d6TCwLMhGGyIDneOzyrbqXCwpjvXT1b0kRq85rK6KprE/OyDR8TppRta+w0wUoI12KabIUppteQcwok42DgN+BjxM53jfmeeoj+13BsQR/FW/rmRMtFr/sU75MnD+vDM7RlH+rnyRBeN95ECZ3M6frprZ15jZ+4fX58zsZWb2U2Z2z1D+gqHPK8zsLjP7qJk9tzfQcK3YBUuLMgAY28aDkzmPYi2ORzq1OuwMSJVk4yhmqcCC2cLajPNQOhQoKaDM5qHux3EYw85AOdMJPHIvdjnkCjS3dRlj32XMKhiNkq2p6rsgo1voJwkXl52ZnLt/FMC1AGBmp7H5ecG3YPPDNb/o7j83tjezp2HzG4pfC+ArALzDzL7a3c/mA41KUB9SdrCyqBkdL3NSZk+8Zqwp9ovCDnLsl4Gn0rltk9kZx+iUKbbaEQb41cFn+7ctr9hPNf8suO0rkTlWrC0CO1sjkDLF5Mc6Zlu0ZV+52JhckGcD+Li7/3HS5noAb3T3L7r7J7H5Na9nzB6J0X12YJlTZdEsA5FOahDBKNqmDrPSo8Ya+6uxKqkYSNTN2lnSTo2pDv0chhwPPrNPBRjFfqtgwQKp0s1krv7Mv5lOdQaYz7G1WAKcfMbrmGUpkLsBwBuG+5ea2QfM7JbpN1YB4AoAnx7a3D2VnSdmdpOZ3W5mt5994AHNzEbJwIGBiyqLB29OaqYkHnCWdqnDqw5UB1TG/nMODOvP6jtsgAFyZGCM3Y0S2zKbsr2OOph9TBjIj33UPNTYbH5ZIGb36poB/LgucewOOM8QAw42Xd0b5Mzs0QC+C8C/mopeA+Cp2KSy9wL4+bk63f1md7/O3a87/ZjLhgqc7+gKjDDUz5EqwmVOnzGP2DeCjgIMBXjjoa6YUOzLxon9ok2x3y6HgwGUsmNcP8a8GFgpEBjbRP2VvVV9xqLiHil92ThqXiowsfFje8aKF5CLFuQAPB/A+9z9MwDg7p9x97Pufg7AL+OvUtJ7AFw19LtyKpsnzDlZZI3RbCyLwhhS7B+ZVrQpA8QM7Bgb6ByG0S7WR7HF2EfpHMsUAHcOR8YEY32si0GABTYGhmrds3lltrN2ip1lfeLYihGy9so+BXqK9bLxlwIeb76OWZYAuRdiSFXN7ElD3fcAuGO6vhXADWZ2qZldDeAaAH8wezQWwcdrddiVU1WOrFKjUadiSyrdiaKAWB0CNcdqjLE/S2+izAUFJV3Q6TKKjEFt9bJ9ifcdJqcYZQTfjCWqINhh7Mym7D7qZzqrfd9VDhTk9vo7OTO7DMDfBfBDQ/HPmtm12EznU9s6d/+Qmb0JwIcBnAHwkvKT1a1EYHnYADzS2QC+cax/BJZq8RnL6TjjVnd2uJld7PCM/SuwY/OM/WNZh7l0QHsUdigzBjLaF98ZaFXr3FkjJQy8qvlHuzt91RgqEGf+Gs9EXLvoV0uBnePi/FqXuz8A4K+Fsu9L2r8KwKtmD8QAaiyvnE31YW3UAbPQprJ1tEPNpaNHtc+AMLaNa8DGyuqy+0wUk2IHjQUpdvjjeqggEfszu+aKArDMjzpjKkarAnJ8V4Es3mf+soRcjCB3bJJFT3ZAskPEHCa2ie1GG9SBjPZWbCyOkbGYaEMlsW8FlMD5c1FMUNnctUvZGseNtjAWnbE01UbZVemK9jGfZKDL2mZgz2xgTKxjaxwzY4YLyPq1rl2lclKVrmRMiR32UUeUyuGzqBnHVIdYlWVgNQegGKNVEZ2tjQokmcxhmXHcbE3YflXBR61dNpYCBWWXGrtil2qPtnVdsGZBOgaIo2JxwMGmq4f/n2aOGxQPgTpo1SHabn50iipl2t53nD+O0YnYShezMbbvMNWKkak6BYyddCyba7aOCrjVHLZ1LI3LQISNFcdk6x7XM+tfBQYG3tEuNZ6a09gvu19KfMbrmOXwmVyUjIl02JliRSzVqFjHGC1VXWZ3lp50nHEcW6UkcWxlIxuzYmFRlI4KsDprFdsz/QosMtn30DMAZfsP0o71Y3XjWEo386uK2S4NOAfK5E4OyHVSsrE867vrWFWKlx3W2CZjRAooOsypmn92GDIQyw4Vq4+2jGMqezIb1KHsBIqsX+dgsj3N1krNe9SXZQ2dtVXjjcKyiY6+HcSANV3dWTqOzZiU0sGoc+zPyivmyKQbedm4zHbD+SCR2TGOz+aYASWzLdrXmX9HqhRu7qFn+hmDV8Abx1HzVikYA3I1TjWvDIxV3yxzOUKxc9567TWG2T82sz+avjb6FjN7XNXn8EFOHWh24DtpHuuvUjzmrHOdJaa08TqO27nPIneVpmZ6Yzk7qHN8tNtWsQ0GIgoQVcBSZZWtWVBjgacaL5tHLM+Y9liu9loxTzbeUhLJQ/baT24D8HXu/rcAfAzAK6oOhw9ync0ZN7ZaSJUOjnUKzBSrVGyNjRmvmXNGx2QsKvZR9o1tx/Ej2CoQ66ZkFeNmtioG3bEjMrwOS4rgwFgiwPdTzbHDxNieZ75WBdOOD2Trx4B0ATmO7666+2+5+5np9t3YfD00lZPzTI5Fs7kLNjKprWSAVqVRmTAWNF532JViDtuyDLDjPQMyxQSqwNIF1ni4x/5sHxjbUYdWtWPC1qgKTOMYY9tdgS67Z/rY+qh2UfdYzjKHWL6UHAVDzOUHAfzLqtHJADl2WNQBr5yDpQJVmjrqimPMAVtlm4q60VlVm2rM2E7pV8A5tnXwNWDtgfPXSTEKZnMsY8wz2sb0KDvn2pLVq8DQ3adMh9LJ9kD5c9zbIwCkGSztCWZ2+3B/s7vf/LAes3cA+Juk3yvd/a1Tm1di8/XQ11eDHT7IdSLjKMw5FKtibSpmlB0MtckMTLI0SfWJNuwKtOw6K9tKBnRjfaZPsaiKIW11MfZRAVy8ZnuQ7V2mL5YB+byy9c0ASI3J1kStrYV+ysZdpa/ns+5+nVTj/h1ZZzP7fgDfCeDZ7l6OevggN0rGorLD1XHgOXpGJ1FOWwEeO3xx3DnlHemyuqr/VuauawVSrF7ZXLk2A6MOc4t2sbFVWWZDVTbqYf7BADr27axJtH0pcRzL17rM7HkAfgLA33H3Bzt9TgbIMSbD7qNTMB0RZGLZXKbRAdMsQkfHy5iWAjg2J2VD1NWVigFmbWOqNJYrlgo8cm0Yy1X9FXMedTKWHEE2sh4F2J05jOWxLAsenT1Sa8F8KmOme4gBx/V3cv8MwKUAbjMzAHi3u/9w1uFkgNwoKl0Y37PUIktRFBhV91FHBjaxnerD2GXmkPFgZ3ZHp2fpS8U2YlsG+Go+GMrGOgUUDJCqNa7AJdPD/KsKZgxgFGNnQXWsr/a7G3Aq8Fqa2dWZ4wJD+H82t8/hgxyLlp3DrzZQtY1Rehc7R/3M4YHzDxA7wEDvIEV92YEf2YeyM+pUYzKmpMZF0jYDyGr9ujInrcvOqALtim3PCTjZ3BTgsUCubO7W7SiH+o2Hwwe5EXSqAzeWRR2Zk7B2FTBlgKucio2n5sD0Zc4a+86xQbGwaAvTrw5ml0WMbRl4dufM9I73bD5snoy9sTaK5SmZC87KvzLbsv7RDsWad5UsyF5gOXyQ24o6VFmKx1hLFdmrdIyBWpQMMFSqwmxRokBGAUMG8rE+A9SMvYzCQJS17TLoCrQZaFUgPOqNgTSOWaWMcdyMIWdrE8dHqGeMXOlXYKYY8gKy/n9y+0i1MZ20a2yXpU8dHUynShui8zMn7gCVmkMcp6pXaVdsF21TgQShPdMRpQtYrK5i7orJjaIC2XitxrGkPuqOc6kC2BxWXDHvDgPu2tWUQwW5JX6S8FNm9kEze//2D/zM7PFmdpuZ3Tm9Xz6Vm5m92szumr5g+/TeIMML+CsQYIdTMYV4iFQqMr4rJxjLFRCMhyG2V3pY/2hb7Mt0McnStmptAT5HJRWwzLlW4zAGqPoY+JpmaxVZrWLH8Vr5nAK/al/V+NHW2DcLcqr/PuIA3HuvY5alvrv6be5+7fAHfi8H8E53vwbAO6d7YPPzhddMr5uw+Y3WXCo6v23DaPmczWMHRUVHBYYRLLJxsjSNAU2HBcT2zKFV+ainWrcsCCiAmQO+THcGepUdcd4ZkHRYE0jbOaDfYYTKztHWcVzFzNmY3XFmysX8u6tMrgfw2un6tQC+eyh/nW/k3QAeF37C8HxRUYo5rGIQFZPKhFF8BgrMJnZA1aGuwEVFfxUExvEUoHbWw8OrAqNMV5RqHorBj/Ud8OwA92gP28tYp9aBBUAWQDPfiPZEfXFMtYdqv48KaKKvqNcxyxIg5wB+y8zea2Y3TWVPdPd7p+s/AfDE6foKAJ8e+t49lT1CzOwmM7vdzG4/+4UH8minDsP2PTpZlhKpDalYUcY24oFRjqucM0vnlMPE/mzeaowMFBHaxb6xnAGF6sf0xz2ogkAFfCNAZWCQjdEFc+UvVZ0qY6Ct/DqzQ5GGPcVwuExuiQ8evtnd7zGzv4HNXyH/0Vjp7m42b2rTl3VvBoBLv/KqR/ZVjG4si3XRWTLAZAdSjafGYAxFgcFYlzmei3ZMXxwzA5aKQcQ2WzsYS1S2sXVVjNNCGwV0Y1s2HkK7eK32aNdDWM2RjRnnEAE4A9VsL9VeZHPfV3z//xDzqGRvJufu90zv9wF4C4BnAPjMNg2d3u+bmt8D4Kqh+5VTWTIA5jl2ts7R8bJoGfVWqcO2PDsoivkp5qQcnqUhcWx1wKINsZ6tbRw3HlA2bhVM2HUcj+lg8xvbV4DN2nZYEfOVLNioILBtowBvbFuxTbaX7KyovqOdS4g3X8cse4GcmV1mZo/dXgN4DoA7ANwK4Map2Y0A3jpd3wrgRdOnrM8E8OdDWqslOgFwvkNsr3cBweiMDPiYM8XDwcbsOmwcg0VwBlwVuMUyBTxVAMjAS9nMdM9xejavuJ5d9qP0xHbMBlbGfI2xshHsFCuN40TwVUFe7eVYF8fMfGxPuVjT1ScCeMv0RdlLAPwf7v5vzOw9AN5kZi8G8McAvndq/zYALwBwF4AHAfxAaxQVbTK2MPbdto19lf6K9mfROQMb1VaNO0dPl/EoBqj0xgNh4HNlc4r6szVmwoLN2H/UE69Z29GmeJ+tZbQ38404HrtXazq2ZeOosaszwGxhAWwfcQAHmq7uBXLu/gkAf5uU/ymAZ5NyB/CSnQZjG8scItYrNvIIw5AfhLF/dCx2EFlUjv2j3VHU4asYaYepZW2Urux+ToAYx++CkrIxjjleZ+sO8L1StikAYv0VW5sDKtm+x/VVPj6OH9cDSfk+cpgYd4K+8ZAdjAoooqjIqsYe+0Tnr3Sxw5JdK2fu2KQOLBs/SmSP3bbqIHeCSzVWh6mydl1GnTHmbB+Znds2GaCqcar1VGuZ7TerU367EDitX9BfUrJDg6FOpVFZNFSOopgQAxw2PtOpdDA7FQix+igZo2UHXbFTZqcat3OIquCVAX0cRwGCGjtjQKqMMcYoyu+YX2Q2qfadQDGHCFS+M0MO9dPVkwFymXNlG6SAJnOU6uDPTYMUULHonx3oLjOq+iCUMWDpgFj3UCnWoA4tW38VqKLdXRuYKP9SgN+Rqj1b54oVx/YVe818vWLsc0SdqwOQwwe5KsJmkZUxr1FU+6hXjVU5YgaAjCVWaU5mbyxXgBDnEOvUvCMYRzvZwYnv47yz4KEkBqoK6DKQ7TBIxsLZGrF1qcA5Y3tsPtn6xmvWV8lSLA6AXYDvpXbk8EFuK8rBWBsm3bQlY13VWF1WyQ6oh3ZxHBatMz2V/VWbDgvqsCm1vmzMWM6CFAOb2L9i/hUgqXXpBg4232recf8r8GPlsWxJptaRA/1fSE4OyAE8klfRO7ZjkTmOwSIsc7hOipSBbhWpAd6/M4/YPwMbID+A8V7NOeuX9c+YZzZG1Ub1YWwoA/wsoGQMt7JR9cmCV2zTYWtRBzs3C8jK5JaQcfOrAxoZ2RzWNfZXaQvTGQ8OA1/WPo6ngLuylZXFOWRtO8EiW4uKeY2iwKgaZ3uv7GTtM8bTBc/OfWee3Tq23xlgZ+t1HNIF+Qsghw9yCjDG+iw9UfpGPR1HVE7XsUsBcpddKhsr1hLXRLEGNhZjOoxhqjJmrwoQVVmVlsV2c/Qpxs/G6R5ilnFUNo/6M4BSgdzDPRtnl7m05XC/u3r4IJexDsXgKj2Mcam0zMR95lDqOh4udeAYoFSO3zmscb7xULE1GMdQ42VSsRtmczZfBtgMlMdyBdBjfZfNRZ1zznW13mOZaqsygs7+sn1YkoGt6eoeojZ1FMWAGBNhzqXqxvIsfVJOpdKp2JeJAnF1EComtW2r7Iw6K0YZy5md6p3ZFvVn7FSJOuwK9Fl5BsxqLTPbOgxNzZuxyg4QsvFZ36XEcbD//fnhg1zFYrppTQZiGWABvcNZ1Wc2qfadA6T0KlAB8gOVMcDRjoyJKnDMmDPbHwVA0VZm96hLAXYcVzEdVp8BZtWH6c0CzjiXaF8Utu/qbHTAd46sTG4PqZhJLGfAxlKhKtKr8bOxmR0KRNQhVaxKpReV3RlgM5CKgBTrFcB3wZH1y4Aojl0Fie6hzQKgYkVZWRX4gJ6d235VYBj1ZevaXeN95TAx7gSA3Bi9AQ4EzDmVrigstUEoi+3V4RiditnbPTBKGCiwqN3RkdVv7VKHVvWvgC5rnwWSOaCasdcMhLJ9jaKAhdkedXfYJdOn/DAGyg6zjuULgZOdO8x89fBBbpQMgLJ0QzElxbCqdqpNHCtGY2YrczAW7ZVjdh1YpTCduUZ9jBnEg6xYXIcVqzoGwIopzWGHGVCMuphUQSHamDGyDOQzQGZgxoJAtCVjq3PFsf4x8M4SnU8dytgntmUHTTlL1BPLxnHVWBm7rCLorgwn2q2AjDk/W6suQMS2HYDc9lXz6LKxOfapdc2YW8YaO0AKUs8CQjbXah3Y+ah8A422M8Tg6x8D7yxqg7NNjG07/ZjDRwdkwMHszA5PdqAyu1jZOA7TyxiEAmllX8YEx/KxTNmr1l8FJGZfFtwqtsVsYcwt6z/qyYJo1Y6NoRhfh3VXax/HqtrsIivI7Shz1k0d1kzHLmnAeB1TCaU32jnHqSubY11sE+sqp67Wo9M3jjnWRxBj5UyfAo/xPtOTzaE6+Ap8GVBmQTAD7Ln2qf0cbetkAkth04GC3M6/8WBmV5nZb5vZh83sQ2b2o1P5T5nZPWb2/un1gqHPK8zsLjP7qJk9d4kJpJFqdKLoiBXwZWNFdlc5UaUrtmesKTLMqEcxHJUKjjoVUCp2ykAq3iumpObL3qO9rJ0l/dRaqfQwC1Sxf5RsPVmZYl9xb6IoNt4JxKye3e8ijs0zuc7rmGUfJncGwI+5+/umH7N5r5ndNtX9orv/3NjYzJ4G4AYAXwvgKwC8w8y+2t3PliNVUXUr2WFlDqtYj4rEFRjMZWNjX3adpXBjewXeGfNhZYqtsDGroF2x2Awox/7xmtkSbY17EPdfgSIbY7Q56o46lU+q4Kh0dIJxl5WzNnFdFpJD/XR1Zybn7ve6+/um688D+AjID0UPcj2AN7r7F939k9j8mM0zeoOF6yy1UICYMSXVZvseyzPA6x7+CAKRAUXdioXs6qRZNM/SLTamhVfGKsb26joCYcZCtvUVm2bgOupWTDmOq8CesfsuAEUdau1VUIqvaBcbc3FxwJuvY5a9f3cVAMzsKQC+HsDvT0UvNbMPmNktZnb5VHYFgE8P3e6GAEUzu8nMbjez288+8IA+KAA/AOpAsqgOcOeKjjM6bZZKdAAiY4BqHmMdO6ijjezFgCBGdNUm88vIbBSIxDYqqIx6IwCoOnbYY59ob7SR+QwDtmzPmA1Zm6hH7fu4VhkAR/vHMRHe477sK46LF+TM7DEA3gzgZe7+OQCvAfBUANcCuBfAz8/V6e43u/t17n7d6csu0w4coyU7CNExGSvqOo4Ck2175tzRyRlTUQdv7FPZF+cY9Sj9cSwG6iwgMNBnYJ4xxjgmO4Rq/grAFAgB59s79onrpoJJJczfMuAD9NznCAtso81szsyWfeRAn8nt++PSj8IG4F7v7r8BAO7+GXc/6+7nAPwy/iolvQfAVUP3K6eyZURFfnZgqkjNHF6lDHGMUW+0T90zfQwwFDAxII36mN4oDOyifRVTnXPdARbWf3uv9kKtAVtDBiqKNTGQZP3U+qigUIF4xuIyiYB3xGLurdciY5n9mJm5mT2harvPp6sG4FcAfMTdf2Eof9LQ7HsA3DFd3wrgBjO71MyuBnANgD/oDQbtCBlrUWDGRLHAsb5ijUB9uBQYKtBi0Z/NR7EGZlMEbDVXxgiYvlFXZModgGTsK7ZVgFT1y2xVIDzeV4wxtol+oACmC2ysTcYEma4qKC8lx5SumtlVAJ4D4P/ttN/n09VvAvB9AD5oZu+fyv4hgBea2bXYLOOnAPwQALj7h8zsTQA+jM0nsy9pfbIK9KKqio7jwctAJXMKhDaV47JDVwFa5ngdUGLtx3pmW8XUGBCotYnjZmuUMWmlb+wb13eUDtuNY8QgpIJI7BtFASdbZzYO81nVX7G7yMaPS9yBs8eWi/4igJ8A8NZO451Bzt1/F3y735b0eRWAV80erANc1YFh5SrVYf1UW/Ue9SlHZray8TC0GceK/VjfyuEroFUAEcdUtimmU60poPeN6c/AR9mfsaVs75SdUS8LonGcas2zgN7ZaxVoq3WbK32W9gQzu324v9ndb+50NLPrAdzj7n+4SSZrOfxvPChHG8tieaUrYytM99gnOkwFll37WL06QNEmhHasnK2jmvvYrmrfAc943zmcDGgyVhzHqIJNJd09jusTx1KAOdqaATdC+ywwjvrVecnAc1/pg9xn3f06VWlm7wDwN0nVK7HJFp8zx6zDBzmgz8JUXWzDRB12dsiUThUZ2eHMUqKqv0pnWN9RdxYwxnHUmMpOBdAKqFhbds/WnB3a6mwxcGA6Y1nGTrOx2P24FkpvRycD+GzMCNaA3td9xAEs9BsP7v4drNzM/gsAVwPYsrgrAbzPzJ7h7n+i9J0MkAN6zIilWwpcMLTN9qbDyiqHqcap2AAbo3LczuEZx2drlIFiFhSU/YpNRhsiOMZ2zJZs77PApOyJY1SAUumOkgFqLFNSsXC2RkcmDvjRPpNz9w8C+BvbezP7FIDr3P2zWb+TA3JVqhSjJGunWEAGUgoU1QHtRHzmcNVhiWUZeGeMl9nADoOq7zDSjOGNEoGrwzDinCp7svQwY6Bsf9S4qi3b004ZK88CV7VXMWjE+mqfOuI4zg8eZsnJAbmusEibMakuEKn0ohMtK7BRtnXbsgOh+rI21QFReiqgjm0yltdJqxjDy2xVtqgDP0oGRmztsvHGMbPgxdZAifLDLMDOZfhz5Zi/zeDuT+m0Oxkg10mbFN0Huc8iWox+GYCw+irNUIyAAUDFqkZ7FJuMbTMgU/VK1Hqr/eqyrmztRqlYezeoqbWOY3QDGOujAmPFlhWgsjGVDSyIdIF6jhzof7V0+CCXRT7mSGO6oRhC1MEOHtObpSGAPlhRtwKtSn92PZYpNtBhoXEuCuQZwC3BmrsHMGPVcf8zUe1UwIlt4rgdhsUCpQqeHXYd+7DzEOe0OKPzFeT2kmpzOuAQ7xkYjnUV+1DC+imnYw7Mom8FrLEsY4QZy4tzYHNlwDnaG8eMtqoDygCX2ajGUaxTMUwFHhWLU4BWscBsXlU/4Px+GRtkYB91ZMFwF3EAB/pfLZ0MkAP4AY737ODH/lUasyuNzxyFOaQSxjC7DCiWKXYQ21W2ZDZkQJwd3oxlAHw/lE0q8LH7zI+UrrG8E/Q6YKfqoj2xDwscccwqIHZZ7lxZmdwewqh4rGOSrXnGAiLrqZhAHEs5LYu0c6NpNv+oSx0mxlzVOBWjqHSow5elV+N1ti5q/RSb7jDyCHbZfDOAj/oY6GWBIdYzJl6BZRc8F8EmXz9d3UuyaA7ULIw5VAekFLgplsF0ZeNWTIzpUHNRgJIxX7YGGeiqA5IFiaz/qGdbr+aegXIHZMZrtU5jXSewjf3YnDtrGNsyUMzsVHWjTVUw6AbYTBzwI/47uV3l8EGORS8GYJlkADDes7FVJI71nXQhmwNry4Cjk66M7SuAU3pZG7ZOipV2WGoEyA7oMlDN9m/bR4kKoIrJqT3uBJjYLpMu8FQMluligWMJWegbD0vL4YMcwKNljFJVWhGvq8i8bV85W+ZkbIwOQGcMKY5ZAbjSkdnEyrtsqSMK7JVtCpDjGncAKIoCQqaX9Y3rXAXOsU7NpcskszGy+cT7pbBpfSa3o3TTBoR2CihGHQpgtm1YyqAO5eikjH2w8dV9tCUDLgWySlfsr5gK61OJAtptWbUOccxtGwWKsSwbV/WN14qxsz7VWjHwzWyINs+xNdarQNsB4V3Eff10dTHppEAVhVcHiwGbGj+O1znACG2zsTrOnx3eypkzAMoOGTtYHUYdRbXtsuCxbbZWGXPPwGdbXrXN1p/1qRhbHIvZy+xjovZqrO9kK11ZmdweotKRCmCqgxTZHtvsuWOoVCo7YGzMqEPZzECP6dqKAnhWHhkfS7MUe62Y9z5gmDHMuI9zGHsGRhlwdezvsOwsODEd6p6Nm9m2CDY5/Gzv/8A9bjkZIAfk0a+KRAwU5zgrc3Y1JnPUWJaxOXUYMnBiB5OVdyVL2dh7lRpFu5Ut7NCpA10BR6dMgUKH4Sk2x3ySXTNfVG2iDpD6qHMsG22s9mdXcawfPOwsnYiUpRLK2cb7imVloDS2GxmWahN1ZCwnO8iKtWVA1xmTScU2lT1zJbOB7bE6wOyQA7mt2f6OotgzY7fKfuD8/egE2tieBZrM1mjb3OBXyYH+Cckiv7s6R8zseWb2UTO7y8xe3u7YodVzUiDlhAAHBIPup/p2U4HxcDAnzFIYNrYCpTjOWMcOyDhfBiyxLZOsvxpT6WCHsmJO8b4LxhnDUu137a9YJwvasX0VxEYAjmBc2TVDHICf89bruOVYQc7MTgP4JQDPB/A0bH705mm9zqgPUkeydCgeRAVSXUY46s3SHhXVs7EN54+r+imQVH06QKNSo24ax9aa2Z4BVhQFxFXaty2Pa1ox3soP4t5nQY+N32GXGfA5zh+T6VwCd9w3TK7zOmY57nT1GQDucvdPAICZvRHA9dj8gtc8UVFuK+qgKz3xQHRYo2J2Bti0l64YSwYUrG02BwbUnXYVoHRZBOtfMYxYlh3uLA3L9jW2zWTcCzXXan0yMGU6o30s4IHUZ76dAbya20KyfvCwkSsAfHq4vxvAN8ZGZnYTgJum2y9+6n/48TtimxMuTwCQ/pfNJ1DWOZ0MYXN68r5KP48/e/s7/NfLH3qe5FjX9CA/eJh+nuxmADCz27Nf9jmJss7pZMg6p764+/OW1rmUHPcHD/cAuGq4v3IqW2WVVVY5EjlukHsPgGvM7GozezSAGwDcesw2rLLKKv8JybGmq+5+xsxeCuDtAE4DuMXdP1R0a/2y9gmTdU4nQ9Y5XQRifqDfN1tllVVWWUKO/Y+BV1lllVWOU1aQW2WVVS5qOViQ2/nrXwcgZvYpM/ugmb3fzG6fyh5vZreZ2Z3T++VTuZnZq6d5fsDMnn5hrd+Imd1iZveZ2R1D2ew5mNmNU/s7zezGCzGXwRY2p58ys3umvXq/mb1gqHvFNKePmtlzh/KD8U0zu8rMftvMPmxmHzKzH53KT/ReLSrufnAvbD6U+DiArwLwaAB/COBpF9quGfZ/CsATQtnPAnj5dP1yAP/LdP0CAL+Jzd+iPxPA719o+ye7vhXA0wHcsescADwewCem98un68sPbE4/BeDHSdunTX53KYCrJ388fWi+CeBJAJ4+XT8WwMcm20/0Xi35OlQm9/DXv9z9LwFsv/51kuV6AK+drl8L4LuH8tf5Rt4N4HFm9qQLYN8jxN3fBeD+UDx3Ds8FcJu73+/ufwbgNgAX7I9GxZyUXA/gje7+RXf/JIC7sPHLg/JNd7/X3d83XX8ewEew+WbRid6rJeVQQY59/euKC2TLLuIAfsvM3jt9RQ0Anuju907XfwLgidP1SZrr3DmclLm9dErdbtmmdTiBczKzpwD4egC/j4t3r2bLoYLcSZdvdvenY/O/rbzEzL51rPRNfnCi/3bnYpjDJK8B8FQA1wK4F8DPX1BrdhQzewyANwN4mbt/bqy7iPZqJzlUkDvRX/9y93um9/sAvAWbFOcz2zR0er9van6S5jp3Dgc/N3f/jLuf9c2Phv4yNnsFnKA5mdmjsAG417v7b0zFF91e7SqHCnIn9utfZnaZmT12ew3gOQDuwMb+7SdWNwJ463R9K4AXTZ96PRPAnw9pxqHJ3Dm8HcBzzOzyKQ18zlR2MBKef34PNnsFbOZ0g5ldamZXA7gGwB/gwHzTzAzArwD4iLv/wlB10e3VznKhP/lQL2w+BfoYNp9kvfJC2zPD7q/C5hO3PwTwoa3tAP4agHcCuBPAOwA8fio3bP4j0Y8D+CCA6y70HCa73oBN+vYQNs9nXrzLHAD8IDYP7e8C8AMHOKf/bbL5A9gAwJOG9q+c5vRRAM8/RN8E8M3YpKIfAPD+6fWCk75XS77Wr3WtssoqF7Ucarq6yiqrrLKIrCC3yiqrXNSygtwqq6xyUcsKcqussspFLSvIrbLKKhe1rCC3yiqrXNSygtwqq6xyUcv/D57gUJx1Jyu0AAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.imshow(imghdu.data, origin='lower', vmin=-5e7, vmax=5e7)\n",
     "plt.colorbar()"
@@ -191,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,21 +131,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Requested exposure time: 1.000 s\n",
-      "Warning: The detector will be saturated!\n",
-      "Exposure parameters:\n",
-      "                DIT: 0.011 s  NDIT: 90\n",
-      "Total exposure time: 0.990 s\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "imghdu_par = metis.readout()[0][1]"
    ]
@@ -223,18 +142,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<matplotlib.image.AxesImage at 0x2a7bcbc1a58>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "plt.imshow(imghdu_par.data, origin='lower', vmin=-5e7, vmax=5e7)"
    ]
@@ -272,7 +180,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -286,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_detector_modes.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_detector_modes.ipynb
@@ -48,7 +48,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package(['instruments/METIS', 'telescopes/ELT', 'locations/Armazones'])"
+    "# sim.download_packages(['METIS', 'ELT', 'Armazones'])"
    ]
   },
   {
@@ -365,13 +365,13 @@
     "plt.plot(detimg_low[1024, 974:1074])\n",
     "plt.title(label=\"low-capacity mode\")\n",
     "plt.hlines(fullwell_low, 0, 100, colors='k', linestyles=\"dashed\")\n",
-    "plt.ylabel(\"Electrons per DIT\")"
+    "plt.ylabel(\"Electrons per DIT\");"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -385,8 +385,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
-   }
+   "version": "3.11.2"
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/METIS/docs/example_notebooks/demos/demo_filter_wheel.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_filter_wheel.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -289,7 +289,7 @@
     "plt.colorbar()\n",
     "plt.subplot(133)\n",
     "plt.imshow(hdu_OD4.data[700:1350, 700:1350], origin='lower', norm=LogNorm(vmin=1e-3, vmax=2e6))\n",
-    "plt.colorbar()"
+    "plt.colorbar();"
    ]
   },
   {
@@ -305,13 +305,43 @@
     "ax2.plot(hdu_OD3.data[800:1250, 1024])\n",
     "ax2.set_title(\"ND filter: 1e-3\")\n",
     "ax3.plot(hdu_OD4.data[800:1250, 1024])\n",
-    "ax3.set_title(\"ND filter: 1e-4\")"
+    "ax3.set_title(\"ND filter: 1e-4\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding a custom filter to the filter wheel\n",
+    "A custom filter that is not in the default filter set can be added to the wheel using the method `add_filter`. A \"filter\" is an object of class `TERCurve` (or one of its subclasses) and the various methods for instantiating such an object can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newfilter = sim.effects.ter_curves.TopHatFilterCurve(transmission=0.9, blue_cutoff=3.8, red_cutoff=3.9, \n",
+    "                                                     name=\"custom_tophat\")\n",
+    "metis['filter_wheel'].add_filter(newfilter)\n",
+    "metis['filter_wheel'].filters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metis['filter_wheel'].change_filter(\"custom_tophat\")\n",
+    "metis['filter_wheel'].current_filter.plot();"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -325,7 +355,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_lss_simple.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_lss_simple.ipynb
@@ -45,7 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -107,7 +107,7 @@
    "source": [
     "plt.figure(figsize=(12,10))\n",
     "plt.imshow(result.data, origin='lower', norm=LogNorm(vmin=100))\n",
-    "plt.colorbar()"
+    "plt.colorbar();"
    ]
   },
   {
@@ -155,13 +155,13 @@
    "source": [
     "plt.figure(figsize=(12,10))\n",
     "plt.imshow(result_2.data, origin='lower', norm=LogNorm(vmin=100))\n",
-    "plt.colorbar()"
+    "plt.colorbar();"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -175,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_metis_lms_efficiency.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_metis_lms_efficiency.ipynb
@@ -29,10 +29,23 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scopesim as sim\n",
+    "sim.bug_report()\n",
+    "\n",
+    "# Edit this path if you have a custom install directory, otherwise comment it out.\n",
+    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../../\""
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When simulating an LMS observation, the user selects a target wavelength by setting `cmd['!OBS.wavelen']`, e.g. 4.2 (microns). The efficiency effect is then instantiated (within scopesim) as"
+    "If you haven't got the instrument package yet, uncomment the following cell. The METIS package provides the spectral trace definition file. The ELT and Armazones packages are not needed for the purposes of this notebook."
    ]
   },
   {
@@ -41,7 +54,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eff = MetisLMSEfficiency(wavelen=4.2, filename=\"TRACE_LMS.fits\")"
+    "# sim.download_packages([\"METIS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When simulating an LMS observation, the user selects a target wavelength by setting `cmd['!OBS.wavelen']`, e.g. 4.2 (microns). In normal use, the efficiency is instantiated as an effect within the `OpticalTrain`. Here, we instantiate the effect directly as"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eff = MetisLMSEfficiency(wavelen=4.2, filename=\"METIS/TRACE_LMS.fits\")"
    ]
   },
   {
@@ -73,7 +102,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, the order can be specified directly. This is used in the following to plot the efficiencies for all orders."
+    "Alternatively, the order can be specified directly. This is used in the following to plot the efficiencies for all orders. The resulting figure can be compared to the original figure from E-REP-ATC-MET-1016."
    ]
   },
   {
@@ -89,7 +118,7 @@
     "plt.ylabel(\"Efficiency\")\n",
     "plt.xticks(np.arange(3.0, 5.05, 0.2))\n",
     "for order in np.arange(22, 37):\n",
-    "    eff = MetisLMSEfficiency(order=order, filename=\"TRACE_LMS.fits\")\n",
+    "    eff = MetisLMSEfficiency(order=order, filename=\"METIS/TRACE_LMS.fits\")\n",
     "    lam = eff.surface.transmission.waveset\n",
     "    effic = eff.surface.transmission(lam)\n",
     "    lammax = lam[np.argmax(effic)]\n",
@@ -100,7 +129,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -114,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/demos/demo_slit_wheel.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_slit_wheel.ipynb
@@ -17,7 +17,7 @@
     "sim.bug_report()\n",
     "\n",
     "# Edit this path if you have a custom install directory, otherwise comment it out.\n",
-    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../../\""
+    "# sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../../\""
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -130,11 +130,45 @@
     "    plt.imshow(implanes[slit][600:1450,], origin='lower')\n",
     "    plt.title(\"Slit \" + slit)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding a slit to the slit wheel\n",
+    "\n",
+    "The slit wheel holds a number of default slits (defined by the configuration for the instrument used). A custom slit can be added using the method `add_slit`. A \"slit\" is an object of class `ApertureMask` and the various methods for instantiating such an object can be used."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "newslit = sim.effects.ApertureMask(name=\"Square\", array_dict={\"x\": [-1, 1, 1, -1], \"y\": [-1, -1, 1, 1]}, \n",
+    "                                   x_unit=\"arcsec\", y_unit=\"arcsec\")\n",
+    "metis['slit_wheel'].add_slit(newslit)\n",
+    "metis['slit_wheel'].slits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metis['slit_wheel'].change_slit(\"Square\")\n",
+    "metis.observe(src, update=True)\n",
+    "implane = metis.image_planes[0].data\n",
+    "plt.imshow(implane[600:1450,], origin='lower')\n",
+    "plt.title(\"Slit \" + metis['slit_wheel'].current_slit.meta['name']);"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -148,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- In all demo notebooks `download_package` has been replaced with `download_packages`. The command is actually commented out so it does not make any difference in automatic testing.
- In `demo_slit_wheel` and `demo_filter_wheel` the new methods `add_slit` and `add_filter` are now demonstrated.
- `demo_metis_lms_efficiency` has been updated and should now be able to find `TRACE_LMS.fits` by itself...

A comment: The notebooks seem to be set up so that automatic tests work. However, the main purpose of these notebooks is to be used interactively by users so as to instruct them on specific effects. In order to do so they need to comment out the local path command and uncomment the `download_packages` command. While the effort is small, it is still somewhat awkward.  