### PR TITLE
Allow version to be read from yaml when publishing a package.

### DIFF
--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -80,28 +80,29 @@ def make_package(pkg_name=None, release="dev"):
         ["dev", "stable"]
 
     """
-    if pkg_name in PKGS:
-        # Collect the info for the version.yaml file
-        timestamp = str(dt.now())[:19]
-        suffix = ".dev" if release == "dev" else ""
-        zip_name = f"{pkg_name}.{timestamp[:10]}{suffix}"
-        version_dict = {"version": f"{timestamp[:10]}{suffix}",
-                        "timestamp": timestamp,
-                        "release": release}
+    assert pkg_name in PKGS, f"{pkg_name} not found in {PKGS.keys()}"
 
-        # Add a version.yaml file to the package
-        pkg_version_path = PKGS_DIR / pkg_name / "version.yaml"
-        with open(pkg_version_path, "w") as f:
-            yaml.dump(version_dict, f)
+    # Collect the info for the version.yaml file
+    timestamp = str(dt.now())[:19]
+    suffix = ".dev" if release == "dev" else ""
+    zip_name = f"{pkg_name}.{timestamp[:10]}{suffix}"
+    version_dict = {"version": f"{timestamp[:10]}{suffix}",
+                    "timestamp": timestamp,
+                    "release": release}
 
-        # Make the zip file
-        zip_package_folder(pkg_name, zip_name)
-        print(f"[{timestamp}]: Compiled package: {zip_name}")
+    # Add a version.yaml file to the package
+    pkg_version_path = PKGS_DIR / pkg_name / "version.yaml"
+    with open(pkg_version_path, "w") as f:
+        yaml.dump(version_dict, f)
 
-        # Update the global dict of packages
-        PKGS[pkg_name]["latest"] = zip_name
-        if release == "stable":
-            PKGS[pkg_name]["stable"] = zip_name
+    # Make the zip file
+    zip_package_folder(pkg_name, zip_name)
+    print(f"[{timestamp}]: Compiled package: {zip_name}")
+
+    # Update the global dict of packages
+    PKGS[pkg_name]["latest"] = zip_name
+    if release == "stable":
+        PKGS[pkg_name]["stable"] = zip_name
 
     return zip_name
 

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -45,7 +45,7 @@ with open(PATH_HERE / "packages.yaml", "r",
     PKGS = yaml.full_load(f_pkgs)
 
 
-def publish(pkg_names=None, compile=False, upload=True,
+def publish(pkg_names=None, compilezip=False, upload=True,
             login=None, password=None):
     """
     Should be as easy as just calling this function to republish all packages
@@ -55,17 +55,17 @@ def publish(pkg_names=None, compile=False, upload=True,
     Parameters
     ----------
     pkg_names : list
-    compile : str, bool
+    compilezip : str, bool
         [False, "stable", "dev"]
     upload : bool
     password : str
 
     """
     for pkg_name in pkg_names:
-        if compile:
-            make_package(pkg_name, release=compile)
+        if compilezip:
+            make_package(pkg_name, release=compilezip)
         if upload:
-            push_to_server(pkg_name, release=compile,
+            push_to_server(pkg_name, release=compilezip,
                            login=login, password=password)
 
 
@@ -193,7 +193,7 @@ def main(argv):
     """
     _pkg_names = []
     if len(argv) > 1:
-        kwargs = {"compile": False, "upload": False}
+        kwargs = {"compilezip": False, "upload": False}
         argv_iter = iter(argv[1:])
         for arg in argv_iter:
             if "-" in arg:
@@ -202,7 +202,7 @@ def main(argv):
                 if "p" in arg:
                     kwargs["password"] = next(argv_iter)
                 if "c" in arg:
-                    kwargs["compile"] = "dev" if "dev" in arg else "stable"
+                    kwargs["compilezip"] = "dev" if "dev" in arg else "stable"
                 if "u" in arg:
                     kwargs["upload"] = True
                 if "h" in arg:

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -217,7 +217,7 @@ def main(argv):
 
         publish(_pkg_names, **kwargs)
 
-        with open(PKGS_DIR / "packages.yaml", "w",
+        with open(PATH_HERE / "packages.yaml", "w",
                   encoding="utf8") as f:
             yaml.dump(PKGS, f)
 

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -14,7 +14,7 @@ ZIPPED_DIR = PKGS_DIR / "_ZIPPED_PACKAGES"
 
 SERVER_DIR = PATH_HERE / "InstPkgSvr"
 
-HELPSTR = """
+HELPSTR = r"""
 Publish stable IRDB packages
 ----------------------------
 This command must be run from the IRDB root directory
@@ -58,6 +58,7 @@ def publish(pkg_names=None, compilezip=False, upload=True,
     compilezip : str, bool
         [False, "stable", "dev"]
     upload : bool
+    login : str
     password : str
 
     """

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -93,7 +93,7 @@ def make_package(pkg_name=None, release="dev"):
 
     # Add a version.yaml file to the package
     pkg_version_path = PKGS_DIR / pkg_name / "version.yaml"
-    with open(pkg_version_path, "w") as f:
+    with open(pkg_version_path, "w", encoding="utf8") as f:
         yaml.dump(version_dict, f)
 
     # Make the zip file

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -247,8 +247,9 @@ def main(argv):
                   encoding="utf8") as f:
             yaml.dump(PKGS, f)
 
-        push_packages_yaml_to_server(login=kwargs["login"],
-                                     password=kwargs["password"])
+        if kwargs["upload"]:
+            push_packages_yaml_to_server(login=kwargs["login"],
+                                         password=kwargs["password"])
 
 
 if __name__ == "__main__":

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -23,6 +23,7 @@ $ python irdb/publish.py -c -u <PKG_NAME> ... <PKG_NAME_N> -l <USERNAME> -p <PAS
 
 -l <USERNAME> : UniVie u:space username - e.g. u\kieranl14
 -p <PASSWORD> : UniVie u:space password
+-d : [update-version] : do not update the version of the package to today
 -c : [compile] all files in a PKG folder to a .zip archive
 -cdev : [compile-dev] like compile, but tags as development version
 -u : [upload] the PKG .zip archive to the server
@@ -46,7 +47,7 @@ with open(PATH_HERE / "packages.yaml", "r",
 
 
 def publish(pkg_names=None, compilezip=False, upload=True,
-            login=None, password=None):
+            login=None, password=None, update_version=True):
     """
     Should be as easy as just calling this function to republish all packages
 
@@ -60,11 +61,16 @@ def publish(pkg_names=None, compilezip=False, upload=True,
     upload : bool
     login : str
     password : str
-
+    update_version : bool
+        True (default): update version in <pkg_name>/version.yaml
+        False: use version in <pkg_name>/version.yaml
+        See make_package().
     """
     for pkg_name in pkg_names:
         if compilezip:
-            make_package(pkg_name, release=compilezip)
+            make_package(pkg_name,
+                         release=compilezip,
+                         update_version=update_version)
         if upload:
             push_to_server(pkg_name, release=compilezip,
                            login=login, password=password)
@@ -108,7 +114,7 @@ def make_package(pkg_name=None, release="dev", update_version=True):
             yaml.dump(version_dict, f)
     else:
         with open(pkg_version_path, encoding="utf8") as f:
-            version_dict = yaml.load(f)
+            version_dict = yaml.safe_load(f)
         timestamp = version_dict["timestamp"]
         release = version_dict["release"]
         suffix = ".dev" if release == "dev" else ""
@@ -212,7 +218,7 @@ def main(argv):
     """
     _pkg_names = []
     if len(argv) > 1:
-        kwargs = {"compilezip": False, "upload": False}
+        kwargs = {"compilezip": False, "upload": False, "update_version": True}
         argv_iter = iter(argv[1:])
         for arg in argv_iter:
             if "-" in arg:
@@ -224,6 +230,8 @@ def main(argv):
                     kwargs["compilezip"] = "dev" if "dev" in arg else "stable"
                 if "u" in arg:
                     kwargs["upload"] = True
+                if "d" in arg:
+                    kwargs["update_version"] = False
                 if "h" in arg:
                     print(HELPSTR)
                     sys.exit()

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -208,6 +208,7 @@ def main(argv):
                     kwargs["upload"] = True
                 if "h" in arg:
                     print(HELPSTR)
+                    sys.exit()
             else:
                 if arg.lower() == "all":
                     _pkg_names = PKGS.keys()

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -12,6 +12,8 @@ PKGS_DIR = PATH_HERE.parent
 OLD_FILES = PKGS_DIR / "_OLD_FILES"
 ZIPPED_DIR = PKGS_DIR / "_ZIPPED_PACKAGES"
 
+PATH_PACKAGES_YAML = PATH_HERE / "packages.yaml"
+
 SERVER_DIR = PATH_HERE / "InstPkgSvr"
 
 HELPSTR = r"""
@@ -41,7 +43,7 @@ $ python irdb/publish.py -cdev -u <PKG_NAME> ... <PKG_NAME_N> -l <USERNAME> -p <
 """
 
 
-with open(PATH_HERE / "packages.yaml", "r",
+with open(PATH_PACKAGES_YAML, "r",
           encoding="utf8") as f_pkgs:
     PKGS = yaml.full_load(f_pkgs)
 
@@ -199,7 +201,7 @@ def push_packages_yaml_to_server(login, password):
         Univie u:space username and password
 
     """
-    local_path = PKGS_DIR / "irdb" / "packages.yaml"
+    local_path = PATH_PACKAGES_YAML
     server_path = "packages.yaml"
 
     cnopts = pysftp.CnOpts()
@@ -243,7 +245,7 @@ def main(argv):
 
         publish(_pkg_names, **kwargs)
 
-        with open(PATH_HERE / "packages.yaml", "w",
+        with open(PATH_PACKAGES_YAML, "w",
                   encoding="utf8") as f:
             yaml.dump(PKGS, f)
 

--- a/irdb/publish.py
+++ b/irdb/publish.py
@@ -41,8 +41,8 @@ $ python irdb/publish.py -cdev -u <PKG_NAME> ... <PKG_NAME_N> -l <USERNAME> -p <
 
 
 with open(PATH_HERE / "packages.yaml", "r",
-          encoding="utf8") as f:
-    PKGS = yaml.full_load(f)
+          encoding="utf8") as f_pkgs:
+    PKGS = yaml.full_load(f_pkgs)
 
 
 def publish(pkg_names=None, compile=False, upload=True,

--- a/irdb/tests/test_publish.py
+++ b/irdb/tests/test_publish.py
@@ -2,10 +2,29 @@ import os
 from os import path as pth
 from datetime import datetime as dt
 
+import pytest
+
 from .. import publish as pub
 
 
-def test_make_packages():
+@pytest.fixture(name="preserve_versions", scope="function")
+def fixture_preserve_versions():
+    """Preserve the versions of test packages."""
+    p_test_package = pub.PKGS_DIR / "test_package" / "version.yaml"
+
+    # Backup version information.
+    b_yaml_packages = pub.PATH_PACKAGES_YAML.read_bytes()
+    b_yaml_test_package = p_test_package.read_bytes()
+
+    # yield instead of return so the fixture can clean up afterwards
+    yield
+
+    # Put the original values back.
+    pub.PATH_PACKAGES_YAML.write_bytes(b_yaml_packages)
+    p_test_package.write_bytes(b_yaml_test_package)
+
+
+def test_make_packages(preserve_versions):
     os.chdir(pth.join(pth.dirname(__file__), "../../"))
     pkg_name = "test_package"
     now = str(dt.now())[:10]
@@ -15,8 +34,8 @@ def test_make_packages():
     assert pth.exists(pth.join("_ZIPPED_PACKAGES", zip_name+".zip"))
 
 
-def run_main():
-    argv = ["", "-c", "-u", "test_package", "-p", "<insert_if_running_locally"]
+def test_run_main(preserve_versions):
+    argv = ["", "-c", "test_package", "-p", "<insert_if_running_locally"]
     pub.main(argv)
 
 

--- a/irdb/tests/test_publish.py
+++ b/irdb/tests/test_publish.py
@@ -64,6 +64,32 @@ def test_run_main_no_update_version():
     assert pckgs_dict["test_package"]["stable"] == "test_package.2022-07-11"
 
 
+def test_versions():
+    """See whether the versions are compatible."""
+
+    release_from_release = {
+        "stable": "stable",
+        "dev": "latest",
+        "latest": "dev",
+    }
+
+    with open(pub.PATH_PACKAGES_YAML, encoding="utf8") as f:
+        pckgs_dict = yaml.safe_load(f)
+
+    for name, package_dict in pckgs_dict.items():
+        path_version = pub.PKGS_DIR / name / "version.yaml"
+        if not path_version.exists():
+            # TODO: should this be disallowed?
+            continue
+        with open(path_version, encoding="utf8") as f:
+            version_dict = yaml.safe_load(f)
+            release_1 = version_dict["release"]
+            version_1 = f"{name}.{version_dict['version']}"
+            release_2 = release_from_release[release_1]
+            version_2 = package_dict[release_2]
+            assert version_1 == version_2
+
+
 # def rename_zips():
 #     from datetime import datetime as dt
 #     from glob import glob

--- a/irdb/tests/test_publish.py
+++ b/irdb/tests/test_publish.py
@@ -1,42 +1,67 @@
+import copy
 import os
 from os import path as pth
 from datetime import datetime as dt
 
 import pytest
+import yaml
 
 from .. import publish as pub
+
+
+PATH_TEST_PACKAGE_VERSION_YAML = pub.PKGS_DIR / "test_package" / "version.yaml"
+NOW = dt.now().strftime("%Y-%m-%d")
 
 
 @pytest.fixture(name="preserve_versions", scope="function")
 def fixture_preserve_versions():
     """Preserve the versions of test packages."""
-    p_test_package = pub.PKGS_DIR / "test_package" / "version.yaml"
 
     # Backup version information.
     b_yaml_packages = pub.PATH_PACKAGES_YAML.read_bytes()
-    b_yaml_test_package = p_test_package.read_bytes()
+    b_yaml_test_package = PATH_TEST_PACKAGE_VERSION_YAML.read_bytes()
+    b_pkgs = copy.deepcopy(pub.PKGS)
 
     # yield instead of return so the fixture can clean up afterwards
     yield
 
     # Put the original values back.
     pub.PATH_PACKAGES_YAML.write_bytes(b_yaml_packages)
-    p_test_package.write_bytes(b_yaml_test_package)
+    PATH_TEST_PACKAGE_VERSION_YAML.write_bytes(b_yaml_test_package)
+    pub.PKGS = b_pkgs
 
 
 def test_make_packages(preserve_versions):
     os.chdir(pth.join(pth.dirname(__file__), "../../"))
     pkg_name = "test_package"
-    now = str(dt.now())[:10]
     zip_name = pub.make_package(pkg_name, release="dev")
 
-    assert zip_name == f"{pkg_name}.{now}.dev"
+    assert zip_name == f"{pkg_name}.{NOW}.dev"
     assert pth.exists(pth.join("_ZIPPED_PACKAGES", zip_name+".zip"))
+
+    version_dict = yaml.safe_load(open(PATH_TEST_PACKAGE_VERSION_YAML))
+    assert version_dict["version"] == f"{NOW}.dev"
 
 
 def test_run_main(preserve_versions):
     argv = ["", "-c", "test_package", "-p", "<insert_if_running_locally"]
     pub.main(argv)
+    with open(PATH_TEST_PACKAGE_VERSION_YAML, encoding="utf8") as f:
+        version_dict = yaml.safe_load(f)
+    assert version_dict["version"] == NOW
+
+
+def test_run_main_no_update_version():
+    argv = ["", "-c", "test_package", "-p", "<insert_if_running_locally", "-d"]
+    pub.main(argv)
+
+    with open(PATH_TEST_PACKAGE_VERSION_YAML, encoding="utf8") as f:
+        version_dict = yaml.safe_load(f)
+    assert version_dict["version"] == "2022-07-11.dev"
+
+    with open(pub.PATH_PACKAGES_YAML, encoding="utf8") as f:
+        pckgs_dict = yaml.safe_load(f)
+    assert pckgs_dict["test_package"]["stable"] == "test_package.2022-07-11"
 
 
 # def rename_zips():


### PR DESCRIPTION
Improves the uploading of packages by not always updating the version.

This code will be used to upload the package for #105.

More importantly, it is a step towards creating a deployment strategy where the version is set first, and the release is created afterwards.

Furthermore, the tests are improved and now they don't pollute the local clone anymore.

