### PR TITLE
typo...

### DIFF
--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -138,7 +138,7 @@ properties :
     wave_max : 2.5
 
   computing :
-    preload_field_of_view : True
+    preload_field_of_views : True
 
   reports:
     preamble_file: "../docs/micado.rst"


### PR DESCRIPTION
Typo in `MICADO/default.yaml`. The scopesim code references the plural form only. `scopesim/defaults.yaml` sets this parameter to `False`, which was thus taken over by the MICADO configuration. This had the funny effect that simply calling `opttrain.fov_manager.fovs` doubled the length of the fov list. Issue on that to follow.