### PR TITLE
make FDR slits available

### DIFF
--- a/MICADO/MASK_slit_15000x20.dat
+++ b/MICADO/MASK_slit_15000x20.dat
@@ -1,0 +1,19 @@
+# description : Slit mask for the long slit (15 arcsec x 20 mas)
+# author : Kieran Leschinski
+# source : ELT-TRE-MCD-56300-0014_3.0
+# date_created  : 2019-07-10
+# date_modified : 2023-07-13
+# status : FDR design
+# type : aperture:slit_geometry
+# x_unit : arcsec
+# y_unit : arcsec
+# changes :
+# - 2019-07-10 (KL) Created the file
+# - 2020-03-24 (KL) Changed geometry to 15000x50mas
+# - 2023-07-13 (OC) Changed geometry to 15000x20mas
+#
+x       y
+-1.5    -0.010
+13.5     -0.010
+13.5     0.010
+-1.5    0.010

--- a/MICADO/MASK_slit_3000x16.dat
+++ b/MICADO/MASK_slit_3000x16.dat
@@ -1,0 +1,18 @@
+# description : Slit mask for the short, narrow slit (3 arcsec x 16 mas)
+# author : Kieran Leschinski
+# source : ELT-TRE-MCD-56300-0014_3.0
+# date_created  : 2019-07-10
+# date_modified : 2023-07-13
+# status : FDR design
+# type : aperture:slit_geometry
+# x_unit : arcsec
+# y_unit : arcsec
+# changes :
+# - 2019-07-10 (KL) Created the file
+# - 2020-03-24 (KL) Changed geometry to 3000x20mas
+# - 2023-07-13 (OC) Changed geometry to 3000x16mas
+x       y
+-1.5    -0.008
+1.5     -0.008
+1.5     0.008
+-1.5    0.008

--- a/MICADO/MASK_slit_3000x48.dat
+++ b/MICADO/MASK_slit_3000x48.dat
@@ -1,0 +1,18 @@
+# description : Slit mask for the short, wide slit  (3 arcsec x 48 mas)
+# author : Kieran Leschinski
+# source : ELT-TRE-MCD-56300-0014_3.0
+# date_created  : 2019-07-10
+# date_modified : 2023-07-13
+# status : FDR design
+# type : aperture:slit_geometry
+# x_unit : arcsec
+# y_unit : arcsec
+# changes :
+# - 2019-07-10 (KL) Created the file
+# - 2020-03-24 (KL) Changed geometry to 3000x50mas
+# - 2023-07-13 (OC) Changed geometry to 3000x48mas
+x       y
+-1.5    -0.024
+1.5     -0.024
+1.5     0.024
+-1.5    0.024

--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -1,8 +1,13 @@
+---
 ### default observation parameters needed for a MICADO simulation
+
 object : configuration
 alias : OBS
 name : MICADO_default_configuration
 description : default parameters needed for a MICADO simulation
+date_modified: 2023-07-13
+changes:
+  - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits
 
 packages :
 - Armazones
@@ -17,6 +22,7 @@ yamls :
 - MICADO_H4RG.yaml
 
 properties :
+  instrument : MICADO
   modes : ["SCAO", "IMG_4mas"]
   airmass : 1.2
   declination : -30
@@ -24,7 +30,6 @@ properties :
   pupil_angle : 0
   dit : 60
   ndit : 1
-  instrument : MICADO
   catg : SCIENCE
   tech : IMAGE
   type : OBJECT
@@ -83,8 +88,51 @@ mode_yamls :
 
 - object : observation
   alias: OBS
+  name : SPEC_15000x20
+  description : "spectrograph : slit size 15000x20mas"
+  yamls :
+  - MICADO_SPEC.yaml
+  properties :
+    trace_file : TRACE_MICADO.fits
+    slit_file : MASK_slit_15000x20.dat
+    filter_name_fw1: Spec_HK
+    filter_name_fw2: open
+    filter_name_pupil: open
+
+- object : observation
+  alias: OBS
+  name : SPEC_3000x48
+  description : "spectrograph : slit size 3000x48mas"
+  yamls :
+  - MICADO_SPEC.yaml
+  properties :
+    trace_file : TRACE_MICADO.fits
+    slit_file : MASK_slit_3000x48.dat
+    filter_name_fw1: Spec_HK
+    filter_name_fw2: open
+    filter_name_pupil: open
+
+- object : observation
+  alias : OBS
+  name : SPEC_3000x16
+  description : "spectrograph : slit size 3000x16mas"
+  yamls :
+  - MICADO_SPEC.yaml
+  properties :
+    trace_file : TRACE_MICADO.fits
+    slit_file : MASK_slit_3000x16.dat
+    filter_name_fw1 : Spec_HK
+    filter_name_fw2 : open
+    filter_name_pupil : open
+
+- object : observation
+  alias: OBS
   name : SPEC_15000x50
   description : "spectrograph : slit size 15000x50mas"
+  deprecate : "Deprecated instrument mode. For spectroscopy use
+  - SPEC_3000x16
+  - SPEC_3000x48
+  - SPEC_15000x20"
   yamls :
   - MICADO_SPEC.yaml
   properties :
@@ -98,6 +146,10 @@ mode_yamls :
   alias: OBS
   name : SPEC_3000x50
   description : "spectrograph : slit size 3000x50mas"
+  deprecate : "Deprecated instrument mode. For spectroscopy use
+  - SPEC_3000x16
+  - SPEC_3000x48
+  - SPEC_15000x20"
   yamls :
   - MICADO_SPEC.yaml
   properties :
@@ -111,6 +163,10 @@ mode_yamls :
   alias: OBS
   name : SPEC_3000x20
   description : "spectrograph : slit size 3000x20mas"
+  deprecate : "Deprecated instrument mode. For spectroscopy use
+  - SPEC_3000x16
+  - SPEC_3000x48
+  - SPEC_15000x20"
   yamls :
   - MICADO_SPEC.yaml
   properties :

--- a/MICADO/test_micado/test_micado_spec.py
+++ b/MICADO/test_micado/test_micado_spec.py
@@ -35,7 +35,10 @@ pytestmark = pytest.mark.skip("Takes too much memory")
 
 
 class TestInit:
-    @pytest.mark.parametrize("modes", [["SCAO", "SPEC_3000x20"],
+    @pytest.mark.parametrize("modes", [["SCAO", "SPEC_3000x16"],
+                                       ["SCAO", "SPEC_3000x48"],
+                                       ["SCAO", "SPEC_15000x20"],
+                                       ["SCAO", "SPEC_3000x20"],
                                        ["SCAO", "SPEC_3000x50"],
                                        ["SCAO", "SPEC_15000x50"]])
     def test_loads_optical_train(self, modes):


### PR DESCRIPTION
- new slit mask files added for the FDR slits 3000x16, 3000x48, 15000x20 according to ELT-TRE-MCD-56300-0014_3.0
- the new slits are made available through new instrument modes defined in `default.yaml`. The old ones are still there, with a newly added deprecation notice. It would be nice if `scopesim.UserCommands` would display these.