### PR TITLE
x position of long slit corrected

### DIFF
--- a/MICADO/MASK_slit_15000x20.dat
+++ b/MICADO/MASK_slit_15000x20.dat
@@ -2,7 +2,7 @@
 # author : Kieran Leschinski
 # source : ELT-TRE-MCD-56300-0014_3.0
 # date_created  : 2019-07-10
-# date_modified : 2023-07-13
+# date_modified : 2023-07-24
 # status : FDR design
 # type : aperture:slit_geometry
 # x_unit : arcsec
@@ -11,9 +11,9 @@
 # - 2019-07-10 (KL) Created the file
 # - 2020-03-24 (KL) Changed geometry to 15000x50mas
 # - 2023-07-13 (OC) Changed geometry to 15000x20mas
-#
+# - 2023-07-24 (OC) Position in x corrected
 x       y
--1.5    -0.010
-13.5     -0.010
-13.5     0.010
--1.5    0.010
+-5.0    -0.010
+10.0    -0.010
+10.0     0.010
+-5.0     0.010

--- a/MICADO/MASK_slit_15000x50.dat
+++ b/MICADO/MASK_slit_15000x50.dat
@@ -2,7 +2,7 @@
 # author : Kieran Leschinski
 # source : My imagination
 # date_created  : 2019-07-10
-# date_modified : 2019-07-10
+# date_modified : 2023-07-24
 # status : Guess - in the train on the way home from CM13
 # type : aperture:slit_geometry
 # x_unit : arcsec
@@ -10,9 +10,10 @@
 # changes :
 # - 2019-07-10 (KL) Created the file
 # - 2020-03-24 (KL) Changed geometry to 15000x50mas
+# - 2023-07-24 (OC) x position changed to design
 #
 x       y
--1.5    -0.025
-13.5     -0.025
-13.5     0.025
--1.5    0.025
+-5.0    -0.025
+10.0    -0.025
+10.0     0.025
+-5.0     0.025


### PR DESCRIPTION
As confirmed by Ric Davies, the long slit should be positioned between -5 and +10 arcsec. This closes #77 .