### PR TITLE
swapped rows 4 and 6

### DIFF
--- a/MICADO/FPA_array_layout.dat
+++ b/MICADO/FPA_array_layout.dat
@@ -2,7 +2,7 @@
 # author : Oliver Czoske
 # sources: E-MCD-FPA-572089EB.uda, ELT-TRE-MCD-56300-0011
 # date_created  : 2017-06-28
-# date_modified : 2022-02-09
+# date_modified : 2023-07-28
 # type : detector:chip_list
 # x_cen_unit : mm
 # y_cen_unit : mm
@@ -21,14 +21,15 @@
 # - 2022-03-03 (KL) added detector angles based on (left, top) = (1,1) pixel from ELT-TRE-MCD-56300-0132
 # - 2022-03-22 (KL) changed column names from x_len to x_size, removed columns xhw, yhw
 # - 2022-03-22 (KL) flipped column 4 and 6 to make plotting in grid format easier
+# - 2023-07-28 (OC) swap rows for detectors 4 and 6 to make id sequential
 #
 id   x_cen   y_cen  x_size  y_size  pixel_size  angle    gain
 1   -63.94   63.94    4096    4096       0.015    0.0     1.0
 2     0.00   63.94    4096    4096       0.015  270.0     1.0
 3    63.94   63.94    4096    4096       0.015  180.0     1.0
-6   -63.94    0.00    4096    4096       0.015    0.0     1.0
-5     0.00    0.00    4096    4096       0.015  180.0     1.0
 4    67.94    0.00    4096    4096       0.015  180.0     1.0
+5     0.00    0.00    4096    4096       0.015  180.0     1.0
+6   -63.94    0.00    4096    4096       0.015    0.0     1.0
 7   -63.94  -63.94    4096    4096       0.015    0.0     1.0
 8     0.00  -63.94    4096    4096       0.015   90.0     1.0
 9    63.94  -63.94    4096    4096       0.015  180.0     1.0


### PR DESCRIPTION
This is a quick fix to #125 for the particular case of MICADO. It brings FITS keyword `EXTNAME = DETi.DATA` in line with the detector id (so that _i_ == id).