### PR TITLE
Add server status badge, improve python versions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Documentation Status](https://readthedocs.org/projects/scopesim-templates/badge/?version=latest)](https://scopesim-templates.readthedocs.io/en/latest/?badge=latest)
 [![Tests](https://github.com/AstarVienna/irdb/actions/workflows/tests.yml/badge.svg)](https://github.com/AstarVienna/irdb/actions/workflows/tests.yml)
+[![Server Status](https://img.shields.io/website.svg?label=IRDB%20Package%20Server&url=https%3A%2F%2Fscopesim.univie.ac.at%2FInstPkgSvr)](https://scopesim.univie.ac.at/InstPkgSvr)
 
-[![Python Version Support](http://github-actions.40ants.com/AstarVienna/irdb/matrix.svg)](https://github.com/AstarVienna/irdb)
+[![Python Version Support](http://github-actions.40ants.com/AstarVienna/irdb/matrix.svg?only=Tests.job_master)](https://github.com/AstarVienna/irdb)
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
@@ -64,5 +65,3 @@ The following development workflow is therefore used:
 - Merging a feature branch into dev_master is only allowed if all tests against ScopeSIM dev_master succeed.
 - Merging a feature branch into dev_master should preferably require a review from a second set of eyes to avoid accidents.
 - dev_master is merged into master whenever ScopeSIM dev_master is merged into master.
-
-


### PR DESCRIPTION
The Python versions badge was a bit messy, showing the whole CI matrix. The relevant information should be the versions the tests use on the `master` branch, so I limited it to that.

Also added a simple badge to check the status of our server. This might not reflect if the download is actually working, but could be a useful indication for users to see if the server is at all there, without needing to find the URL manually.