### PR TITLE
Remove refence to MICADO_Sci and use MCAO where desired

### DIFF
--- a/MICADO/docs/example_notebooks/1_scopesim_MCAO_4mas_galaxy-TLDR.ipynb
+++ b/MICADO/docs/example_notebooks/1_scopesim_MCAO_4mas_galaxy-TLDR.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "gal = sim_tp.extragalactic.galaxies.spiral_two_component(extent=16*u.arcsec, fluxes=(15, 15)*u.mag)\n",
     "\n",
-    "cmd = sim.UserCommands(use_instrument=\"MICADO\", set_modes=[\"SCAO\", \"IMG_4mas\"])\n",
+    "cmd = sim.UserCommands(use_instrument=\"MICADO\", set_modes=[\"MCAO\", \"IMG_4mas\"])\n",
     "cmd.update(properties={\n",
     "    \"!OBS.filter_name_fw1\": \"open\", \n",
     "    \"!OBS.filter_name_fw2\": \"H\", \n",
@@ -124,7 +124,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/MICADO/docs/example_notebooks/1_scopesim_MCAO_4mas_galaxy.ipynb
+++ b/MICADO/docs/example_notebooks/1_scopesim_MCAO_4mas_galaxy.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "### Download the relevant scopesim instrument packages\n",
     "\n",
-    "We will need the ``MICADO_Sci`` package, as well as the support packages for ``Armazones``, the ``ELT``, and ``MORFEO``. If you have not yet downloaded the packages, you can use the ``download_packages`` command. \n",
+    "We will need the ``MICADO`` package, as well as the support packages for ``Armazones``, the ``ELT``, and ``MORFEO``. If you have not yet downloaded the packages, you can use the ``download_packages`` command. \n",
     "\n",
     "    sim.download_packages([\"Armazones\", \"ELT\", \"MORFEO\", \"MICADO\"])\n",
     "    \n",
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cmd = sim.UserCommands(use_instrument=\"MICADO\", set_modes=[\"SCAO\", \"IMG_4mas\"])"
+    "cmd = sim.UserCommands(use_instrument=\"MICADO\", set_modes=[\"MCAO\", \"IMG_4mas\"])"
    ]
   },
   {
@@ -306,7 +306,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
From Carmelo

> Hi. are these https://github.com/AstarVienna/irdb/tree/master/MICADO/docs/example_notebooks (dev_master) the examples that j-uwe is using? I notice that the number 1-*pynb claim to point to MCAO-MORFEO sims, however
>
>    cmd = sim.UserCommands(use_instrument="MICADO", set_modes=["SCAO", "IMG_4mas"])
>
> instead of
>
>    cmd = sim.UserCommands(use_instrument="MICADO", set_modes=["MCAO", "IMG_4mas"])

> Other issue. From the 1_scopesim_MCAO_4mas_galaxy.ipynb
>> "Download the relevant scopesim instrument packages We will need the MICADO_Sci ... "
> is not the case it uses now MICADO

Both fixed
