### PR TITLE
Replace file_name with filename in Effect kwargs

### DIFF
--- a/HAWKI/HAWKI_H2RG.yaml
+++ b/HAWKI/HAWKI_H2RG.yaml
@@ -37,7 +37,7 @@ effects :
     description : Quantum efficiency curves for each detector
     class : QuantumEfficiencyCurve
     kwargs :
-        file_name : QE_detector_H2RG.dat
+        filename : QE_detector_H2RG.dat
 
 -   name: exposure_action
     description: Summing up sky signal for all DITs and NDITs

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -18,7 +18,7 @@ properties:
   readout_noise: 70         # electrons, AI on RvB: check
   layout:
     file_name: "FPA_metis_lms_layout.dat"
-  qe_curve:
+  quantum_efficiency:
     file_name: "QE_detector_H2RG_METIS.dat"
   linearity:
     file_name: "FPA_linearity_HxRG.dat"

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -29,7 +29,7 @@ effects:
     description: METIS IMG-LM detector array list
     class: DetectorList
     kwargs:
-      file_name: "!DET.layout.file_name"
+      filename: "!DET.layout.file_name"
 
   - name: detector_readout_parameters
     description: Readout parameters for H2RG detector (fast and slow modes)

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -31,7 +31,7 @@ effects:
     description: METIS detector array list
     class: DetectorList
     kwargs:
-      file_name: "!DET.layout.file_name"
+      filename: "!DET.layout.file_name"
 
   - name: detector_readout_parameters
     description: Readout modes for Aquarius detector
@@ -54,7 +54,7 @@ effects:
     class: QuantumEfficiencyCurve
     include: false    # QE file does not exist
     kwargs:
-      file_name: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.file_name"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -27,7 +27,7 @@ effects:
     description: METIS IMG-N detector array list
     class: DetectorList
     kwargs:
-      file_name: "!DET.layout.file_name"
+      filename: "!DET.layout.file_name"
 
   - name: detector_readout_parameters
     description: Readout modes for Geosnap detector (high and low capacity)
@@ -55,7 +55,7 @@ effects:
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
-      file_name: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.file_name"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT


### PR DESCRIPTION
`file_name` as a kwarg does seem to work, but it behaves differently from `filename`. In particular, with `file_name` the absolute path of the file is used, and with `filename` the relative path (or well, the actual given path). I have not investigated why.

The reason for harmonizing is that when generating FITS keywords, we'd like to have them to have the filename as it was given by the user or the irdb, not the absolute path where this file happens to be on this particular installation.

Do we perhaps want to force `file_name`?

E.g. put an assert in `data_container.py` instead of a fallback: https://github.com/AstarVienna/ScopeSim/blob/36df1767c2b8143a199d085cdf1af181660c058a/scopesim/effects/data_container.py#L63-L64
```python
        if filename is None and "file_name" in kwargs:
            filename = kwargs["file_name"]
```
to
```python
        assert "file_name" not in kwargs, "Please use filename instead of file_name"
```
or maybe a deprecation notice would be better.

But that is a ScopeSim problem; this PR is just making the IRDB consistent.