### PR TITLE
Disble SourceDescriptionFitsKeywords for MICADO

### DIFF
--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -76,13 +76,15 @@ effects :
         noise_std : 12
         n_channels : 64
 
+# SourceDescriptionFitsKeywords are disabled by default because they still cause problems.
 # ValueError: The header keyword 'SIM SRC0 function_call' with its value is too long
 # "'scopesim_templates.stellar.clusters.cluster(mass=10000, distance=2000, core_radius=0.1, tidal_radius=None, multiplicity_object=None, seed=9001)'"
-
+# See also https://github.com/AstarVienna/ScopeSim_Templates/issues/69
+# and https://github.com/AstarVienna/ScopeSim_Templates/issues/70
 -   name : source_fits_keywords
     decription : adds meta data from Source object to FITS header
     class : SourceDescriptionFitsKeywords
-    include : True
+    include : False
 
 # ValueError: The header keyword 'SIM EFF0 description' with its value is too long
 # "'atmospheric spectra pulled from the skycalc server'"


### PR DESCRIPTION
The SourceDescriptionFitsKeywords still cause problems, see https://github.com/AstarVienna/ScopeSim_Templates/issues/70 https://github.com/AstarVienna/ScopeSim_Templates/issues/69