### PR TITLE
Replace all remaining file_name with filename

### DIFF
--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -4,9 +4,10 @@ object: detector
 alias: DET
 name: metis_lms_detector_array
 description: A set of 4 H2RG detectors
-date_modified: 2021-12-16
+date_modified: 2024-03-25
 changes:
   - 2021-12-16 (OC) some rearrangements
+  - 2024-03-25 (FH) filename instead of file_name
 
 properties:
   image_plane_id: 0
@@ -18,11 +19,11 @@ properties:
   dark_current: 0.1         # [e-/s]
   readout_noise: 70         # electrons, AI on RvB: check
   layout:
-    file_name: "FPA_metis_lms_layout.dat"
+    filename: "FPA_metis_lms_layout.dat"
   qe_curve:
-    file_name: "QE_detector_H2RG_METIS.dat"
+    filename: "QE_detector_H2RG_METIS.dat"
   linearity:
-    file_name: "FPA_linearity_HxRG.dat"
+    filename: "FPA_linearity_HxRG.dat"
 
 effects:
   - name: detector_array_list
@@ -30,13 +31,13 @@ effects:
     class: DetectorList
     include: true
     kwargs:
-      filename: "!DET.layout.file_name"
+      filename: "!DET.layout.filename"
 
   - name: quantum_efficiency
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
-      filename: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.filename"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT
@@ -63,7 +64,7 @@ effects:
     description: Linearity characteristics of H2RG chips
     class: LinearityCurve
     kwargs:
-      filename: "!DET.linearity.file_name"
+      filename: "!DET.linearity.filename"
 
   - name: readout_noise
     description: Readout noise frames

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -4,12 +4,13 @@ object: detector
 alias: DET
 name: METIS_DET_IMG_LM
 description: A single H2RG detector
-date_modified: 2021-12-26
+date_modified: 2024-03-25
 changes:
   - 2021-12-16 (OC) some rearrangements
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
   - 2022-01-26 (OC) added DET.detector
   - 2022-02-21 (OC) rename effects
+  - 2024-03-25 (FH) filename instead of file_name
 
 properties:
   detector:  HAWAII2RG
@@ -18,18 +19,18 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   layout:
-    file_name: "FPA_metis_img_lm_layout.dat"
+    filename: "FPA_metis_img_lm_layout.dat"
   qe_curve:
-    file_name: "QE_detector_H2RG_METIS.dat"
+    filename: "QE_detector_H2RG_METIS.dat"
   linearity:
-    file_name: "FPA_linearity_HxRG.dat"
+    filename: "FPA_linearity_HxRG.dat"
 
 effects:
   - name: detector_array
     description: METIS IMG-LM detector array list
     class: DetectorList
     kwargs:
-      filename: "!DET.layout.file_name"
+      filename: "!DET.layout.filename"
 
   - name: detector_readout_parameters
     description: Readout parameters for H2RG detector (fast and slow modes)
@@ -53,7 +54,7 @@ effects:
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
-      filename: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.filename"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT
@@ -82,7 +83,7 @@ effects:
     description: Linearity characteristics of H2RG_1-5 chips
     class: LinearityCurve
     kwargs:
-      filename: "!DET.linearity.file_name"
+      filename: "!DET.linearity.filename"
 
   - name: readout_noise
     description: Readout noise frames

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -4,11 +4,12 @@ object: detector
 alias: DET
 name: METIS_DET_IMG_N_Aquarius
 description: Aquarius detector for METIS IMG-NQ
-date-modified: 2022-02-21
+date-modified: 2024-03-25
 changes:
   - 2021-12-16 (OC) some rearrangements
   - 2021-12-26 (OC) added DetectorModePropertiesSetter and DET.detector
   - 2022-02-21 (OC) rename effects
+  - 2024-03-25 (FH) filename instead of file_name
 
 properties:
   detector: Raytheon Aquarius
@@ -21,18 +22,18 @@ properties:
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
   readout_noise: 12
   layout:
-    file_name: "FPA_metis_img_nq_aquarius_layout.dat"
+    filename: "FPA_metis_img_nq_aquarius_layout.dat"
   qe_curve:
-    file_name: "QE_detector_Aquarius.dat"
+    filename: "QE_detector_Aquarius.dat"
   linearity:
-    file_name: "FPA_linearity_Aquarius.dat"
+    filename: "FPA_linearity_Aquarius.dat"
 
 effects:
   - name: detector_array
     description: METIS detector array list
     class: DetectorList
     kwargs:
-      filename: "!DET.layout.file_name"
+      filename: "!DET.layout.filename"
 
   - name: detector_readout_parameters
     description: Readout modes for Aquarius detector
@@ -55,7 +56,7 @@ effects:
     class: QuantumEfficiencyCurve
     include: false    # QE file does not exist
     kwargs:
-      filename: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.filename"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT
@@ -82,7 +83,7 @@ effects:
     description: Linearity characteristics of Aquarius chip
     class: LinearityCurve
     kwargs:
-      filename: "!DET.linearity.file_name"
+      filename: "!DET.linearity.filename"
 
   - name: readout_noise
     description: Readout noise frames

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -4,12 +4,13 @@ object: detector
 alias: DET
 name: METIS_DET_IMG_N_GeoSnap
 description: Teledyne GeoSnap Detector
-date_modified: 2022-02-21
+date_modified: 2024-03-25
 changes:
   - 2021-12-16 (OC) some rearrangements, chopnod off by default
   - 2022-01-25 (KL, OC) added DetectorModePropertiesSetter effect
   - 2022-01-26 (OC) added DET.detector, linearity set explicitely
   - 2022-02-21 (OC) rename effects
+  - 2024-03-25 (FH) filename instead of file_name
 
 properties:
   detector: Teledyne GeoSnap
@@ -18,16 +19,16 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   layout:
-    file_name: "FPA_metis_img_n_geosnap_layout.dat"
+    filename: "FPA_metis_img_n_geosnap_layout.dat"
   qe_curve:
-    file_name: "QE_detector_geosnap.dat"
+    filename: "QE_detector_geosnap.dat"
 
 effects:
   - name: detector_array
     description: METIS IMG-N detector array list
     class: DetectorList
     kwargs:
-      filename: "!DET.layout.file_name"
+      filename: "!DET.layout.filename"
 
   - name: detector_readout_parameters
     description: Readout modes for Geosnap detector (high and low capacity)
@@ -55,7 +56,7 @@ effects:
     description: Quantum efficiency curves for each detector
     class: QuantumEfficiencyCurve
     kwargs:
-      filename: "!DET.qe_curve.file_name"
+      filename: "!DET.qe_curve.filename"
 
   - name: auto_exposure
     description: automatic determination of DIT and NDIT


### PR DESCRIPTION
I guess those were missed in #147? Anyway, they caused some errors and also a hard-to-trackdown weirdness of wrong detector layout (imaging layout was used in IFU mode). This fixed it.