### PR TITLE
Add WCU mode to METIS

### DIFF
--- a/METIS/METIS_WCU.yaml
+++ b/METIS/METIS_WCU.yaml
@@ -1,0 +1,26 @@
+---
+### METIS WCU MODE
+
+object: instrument
+alias: INST
+name: wcu
+description: warm calibration unit mode
+date_modified: 2024-04-06
+changes:
+  - 2024-04-06 (FH) created file
+
+properties:
+
+effects: []
+
+---
+### default simulation parameters needed for a METIS simulation
+object: simulation
+alias: SIM
+name: METIS_simulation_parameters
+description: RC simulation parameters which need to change for a METIS run
+
+properties:
+  spectral:
+    spectral_bin_width: !!float 1E-3   # microns, defines fov wavelengths
+    spectral_resolution: 5000          # defines skycalc resolution

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -186,6 +186,21 @@ mode_yamls:
       adc: false
       detector_readout_mode: slow
 
+  - object: observation
+    alias: OBS
+    name: wcu
+    description: "METIS WCU calibration mode"
+    yamls:
+      - METIS_IMG_LM.yaml
+      - METIS_DET_IMG_LM.yaml
+    properties:
+      psf_file: PSF_SCAO_9mag_06seeing.fits
+      filter_name: Lp
+      nd_filter_name: open
+      slit: false
+      adc: const_90
+      detector_readout_mode: fast
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -27,7 +27,7 @@ yamls:
 
 properties:
   instrument: "METIS"
-  modes: ["img_lm"]
+  modes: ["light", "img_lm"]
   airmass: 1.2
   declination: -30
   hour_angle: 0
@@ -59,13 +59,26 @@ properties:
   nd_filter_name: open
 
 mode_yamls:
+  - object: instrument
+    alias: OBS
+    name: light
+    description: "Normal observation mode, includes upstream telescope optics"
+    yamls:
+      - Armazones.yaml
+      - ELT.yaml
+
+  - object: instrument
+    alias: OBS
+    name: wcu
+    description: "METIS WCU calibration mode"
+    yamls:
+      - METIS_WCU.yaml
+
   - object: observation
     alias: OBS
     name: img_lm
     description: "METIS LM-band imaging"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
@@ -81,8 +94,6 @@ mode_yamls:
     name: img_n
     description: "METIS N-band imaging"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_IMG_N.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
@@ -100,8 +111,6 @@ mode_yamls:
     name: lss_l
     description: "METIS L-band slit spectroscopy"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
@@ -120,8 +129,6 @@ mode_yamls:
     name: lss_m
     description: "METIS M-band slit spectroscopy"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
@@ -140,8 +147,6 @@ mode_yamls:
     name: lss_n
     description: "METIS N-band slit spectroscopy"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_IMG_N.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
@@ -160,8 +165,6 @@ mode_yamls:
     name: lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
     properties:
@@ -177,29 +180,12 @@ mode_yamls:
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
     yamls:
-      - Armazones.yaml
-      - ELT.yaml
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml
     properties:
       slit: false
       adc: false
       detector_readout_mode: slow
-
-  - object: observation
-    alias: OBS
-    name: wcu
-    description: "METIS WCU calibration mode"
-    yamls:
-      - METIS_IMG_LM.yaml
-      - METIS_DET_IMG_LM.yaml
-    properties:
-      psf_file: PSF_SCAO_9mag_06seeing.fits
-      filter_name: Lp
-      nd_filter_name: open
-      slit: false
-      adc: const_90
-      detector_readout_mode: fast
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -5,7 +5,7 @@ object: configuration
 alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
-date_modified: 2022-03-14
+date_modified: 2024-04-03
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
   - 2021-12-16 (OC) default slits renamed
@@ -15,6 +15,7 @@ changes:
   - 2022-02-20 (OC) pupil_transmission now an OBS parameter
   - 2022-02-21 (OC) linear interpolation, cosmetics
   - 2022-03-14 (OC) use single PSF file
+  - 2024-04-03 (FH) add wcu mode, move telescope yamls to individual modes
 
 packages:
   - Armazones
@@ -22,8 +23,6 @@ packages:
   - METIS
 
 yamls:
-  - Armazones.yaml
-  - ELT.yaml                # overrides below
   - METIS.yaml
 
 properties:
@@ -65,6 +64,8 @@ mode_yamls:
     name: img_lm
     description: "METIS LM-band imaging"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
@@ -80,6 +81,8 @@ mode_yamls:
     name: img_n
     description: "METIS N-band imaging"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_IMG_N.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
@@ -97,6 +100,8 @@ mode_yamls:
     name: lss_l
     description: "METIS L-band slit spectroscopy"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
@@ -115,6 +120,8 @@ mode_yamls:
     name: lss_m
     description: "METIS M-band slit spectroscopy"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
@@ -133,6 +140,8 @@ mode_yamls:
     name: lss_n
     description: "METIS N-band slit spectroscopy"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_IMG_N.yaml
       - METIS_LSS.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
@@ -151,6 +160,8 @@ mode_yamls:
     name: lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
     properties:
@@ -166,6 +177,8 @@ mode_yamls:
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
     yamls:
+      - Armazones.yaml
+      - ELT.yaml
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml
     properties:

--- a/METIS/tests/test_metis.py
+++ b/METIS/tests/test_metis.py
@@ -230,7 +230,7 @@ class TestObserves:
         src = star_field(100, 0, 10, width=10, use_grid=True)
 
         cmds = scopesim.UserCommands(use_instrument="METIS",
-                                     set_modes=['img_lm'])
+                                     set_modes=["light", "img_lm"])
         metis = scopesim.OpticalTrain(cmds)
         metis['detector_linearity'].include = False
 
@@ -257,7 +257,7 @@ class TestObserves:
         src = star_field(100, 0, 10, width=10, use_grid=True)
 
         cmds = scopesim.UserCommands(use_instrument="METIS",
-                                     set_modes=["img_n"])
+                                     set_modes=["light", "img_n"])
 
         metis = scopesim.OpticalTrain(cmds)
         metis['chop_nod'].include = False

--- a/METIS/tests/test_metis.py
+++ b/METIS/tests/test_metis.py
@@ -14,7 +14,7 @@ from matplotlib import pyplot as plt
 from matplotlib.colors import LogNorm
 
 import scopesim
-from scopesim.source.source_templates import star_field
+from scopesim.source.source_templates import star_field, empty_sky
 #import scopesim_templates as sim_tp
 
 PLOTS = False
@@ -280,3 +280,21 @@ class TestObserves:
             plt.show()
 
         assert mx > med + 3 * std
+
+    def test_wcu_modes_disables_upstream(self):
+        cmd = scopesim.UserCommands(
+            use_instrument="METIS",
+            set_modes=["wcu", "img_n"])
+        opt = scopesim.OpticalTrain(cmd)
+        opt.observe(empty_sky())
+        h_wcu = opt.readout()
+
+        cmd = scopesim.UserCommands(
+            use_instrument="METIS",
+            set_modes=["light", "img_n"])
+        opt = scopesim.OpticalTrain(cmd)
+        opt.observe(empty_sky())
+        h_obs = opt.readout()
+
+        # WCU must be less because atmo emission is not present
+        assert h_obs[0][1].data.mean() > h_wcu[0][1].data.mean()


### PR DESCRIPTION
The corresponding source objects will be added in `ScopeSim_Templates`.

I ended up splitting the "upstream stuff" (i.e. location and telescope) into a separate mode, for now called "light". I'm open to better name suggestions, the reason I choose "light" was because I know the term "light frame" for anything that observes "through the telescope" (like actual observations, but also things like dome flats) as opposed to "dark frame" without the telescope in the optical path.

The reason for splitting this in the first place (and not just adding the two yamls to all other modes like I did in my first attempt) as that the WCU mode will need to work for multiple different instrument modes (image, lss, ifu, ...) and so the other option would have been separate modes "wcu_img_n", "wcu_img_lm", "wcu_lss_n", etc etc etc. The split is also similar in concept to the SCAO/MCAO + "actual mode" split in MICADO.

I realize that might break some existing code which doesn't explicitly set the new "ligth" mode yet (although the default does). For the time being, a temporary "solution" might be to keep this change in a "dev" version of the METIS IRDB package (that's fully supported after all), so the default `sim.download_packages` will still have the old mode...