### PR TITLE
add rectification, needs cleaning

### DIFF
--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -17,7 +17,7 @@
     "sim.bug_report()\n",
     "\n",
     "# Edit this path if you have a custom install directory, otherwise comment it out. [For ReadTheDocs only]\n",
-    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../\""
+    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"./\""
    ]
   },
   {
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -273,7 +273,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Before showing the background subtracted spectra, we convert the pixel numbers to wavelength and spatial position along the slit. This is possible because the current version of Scopesim/METIS by default uses perfectly linear mapping of the spectra onto the detector. The WCS keywords to use are in `metis['spectral_traces'].meta`. The plots will be restricted to the area covered by the spectra."
+    "**NEW**: subtract bgresult from all results. Use rectify on results. Rectified spectra have WCS that can be used to display as before."
    ]
   },
   {
@@ -282,13 +282,44 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# meta = metis['spectral_traces'].meta\n",
+    "for (_, result) in results.items():\n",
+    "    result[1].data -= bgresult[1].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rectified = {}\n",
+    "tracelist = metis['spectral_traces']\n",
+    "for i, (model, result) in enumerate(results.items()):\n",
+    "    rectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before showing the rectified spectra, we convert the pixel numbers to wavelength and spatial position along the slit. For this purpose we use the WCS keywords in the headers of the rectified HDUs. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.wcs import WCS\n",
+    "hdr = rectified['cav'][1].header\n",
+    "wcs = WCS(hdr)\n",
+    "naxis1, naxis2 = hdr['NAXIS1'], hdr['NAXIS2']\n",
+    "det_xi = wcs.all_pix2world(1, np.arange(naxis2), 0)[1] * u.Unit(wcs.wcs.cunit[1])\n",
+    "det_xi = det_xi.to(u.arcsec)\n",
     "\n",
-    "# det_xi = meta['CRVAL1'] + meta['CDELT1'] * (np.arange(2048) + 1 - meta['CRPIX1'])  * u.Unit(meta['CUNIT1'])\n",
-    "# det_xi = det_xi.to(u.arcsec)\n",
-    "\n",
-    "# det_wave = (meta['CRVAL2'] + meta['CDELT2'] * (np.arange(2048) + 1 - meta['CRPIX2'])) * u.Unit(meta['CUNIT2'])\n",
-    "# det_wave = det_wave.to(u.um)          "
+    "det_wave = wcs.all_pix2world(np.arange(naxis1), 1, 0)[0] * u.Unit(wcs.wcs.cunit[0])\n",
+    "det_wave = det_wave.to(u.um)          "
    ]
   },
   {
@@ -297,26 +328,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ilim = np.array([750, 1300])    # pixels along spatial direction\n",
-    "# jlim = np.array([300, 1750])    # pixels along wavelength direction\n",
-    "# xlim = det_xi[ilim].value\n",
-    "# ylim = det_wave[jlim].value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# plt.figure(figsize=(15, 8))\n",
-    "# for i, (model, result) in enumerate(results.items()):\n",
-    "#     plt.subplot(1, 3, i+1)\n",
-    "#     plt.imshow((result[1].data - bgresult[1].data)[jlim[0]:jlim[1], ilim[0]:ilim[1]], origin='lower', norm=LogNorm(),\n",
-    "#               extent=(xlim[0], xlim[1], ylim[0], ylim[1]), aspect='auto')\n",
-    "#     plt.xlabel(r\"position along slit [arcsec]\")\n",
-    "#     plt.ylabel(r\"Wavelength [$\\mu$m]\")\n",
-    "#     plt.title(model);"
+    "plt.figure(figsize=(15, 15))\n",
+    "for i, (model, result) in enumerate(rectified.items()):\n",
+    "    plt.subplot(3, 1, i+1)\n",
+    "    plt.imshow(result[1].data, origin='lower', norm=LogNorm(),\n",
+    "               extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
+    "    plt.ylabel(r\"position along slit [arcsec]\")\n",
+    "    plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
+    "    plt.title(model);"
    ]
   },
   {
@@ -795,7 +814,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.2"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -17,7 +17,7 @@
     "sim.bug_report()\n",
     "\n",
     "# Edit this path if you have a custom install directory, otherwise comment it out. [For ReadTheDocs only]\n",
-    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"./\""
+    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../\""
    ]
   },
   {
@@ -190,6 +190,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that the source object does not cover the entire spatial and wavelength range permitted by METIS: The spatial extent is about 2.5 arcsec, compared to the METIS slit length of 8 arcsec. The wavelength range is 3.1 to 4 $\\mu$m, whereas METIS permits 2.9 to 4.2 $\\mu$m. This will be visible in the simulated raw and rectified spectra below."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Simulation with Scopesim"
    ]
   },
@@ -220,22 +227,6 @@
    "outputs": [],
    "source": [
     "metis = sim.OpticalTrain(cmd)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Raw METIS data will be stored as unsigned integer. For the purposes of this notebook, this is not required and it will be simpler to deal with real data. We therefore switch the `Quantization` effect off."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "metis['quantization'].include = False"
    ]
   },
   {
@@ -366,6 +357,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "As stated above the input source object does not fill the entire spatial and wavelength ranges covered by METIS. In a real observation the entire frame shown here would be filled."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The results have to be saved to disk explicitely so they can be analysed with external tools. "
    ]
   },
@@ -375,10 +373,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from pathlib import Path\n",
+    "\n",
     "# Change to True if you want to save the rectified data\n",
     "save_rectified = False\n",
     "if save_rectified:\n",
-    "    from pathlib import Path\n",
     "    for i, (model, result) in enumerate(rectified.items()):\n",
     "        outfile = Path(fitsfiles[model]).stem + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
     "        result.writeto(outfile, overwrite=True)\n",
@@ -568,7 +567,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The pixel values in the detector images give electrons accumulated over the exposure time. To get back to physical units, e.g. Jy, one has to perform a flux calibration. As in real observations, we do this here with the observational of a standard star. For simplicity, we use a star with a spectrum that is constant at $f_{\\nu} = 1\\,\\mathrm{Jy}$. We observe it with the identical setup as the science targets above, except that the exposure time is reduced to 1 second."
+    "The pixel values in the detector images give electrons accumulated over the exposure time. To get back to physical units, e.g. Jy, one has to perform a flux calibration. As in real observations, we do this here with the observation of a standard star. For simplicity, we use a star with a spectrum that is constant at $f_{\\nu} = 1\\,\\mathrm{Jy}$. We observe it with the identical setup as the science targets above, except that the exposure time is reduced to 1 second."
    ]
   },
   {
@@ -600,18 +599,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "std_bgsub = std_result[1].data - bgresult[1].data / exptime\n",
-    "\n",
-    "plt.figure(figsize=(10, 10))\n",
-    "plt.imshow(std_bgsub[250:1750, 800:1250], origin='lower', extent=(800, 1250, 250, 1750))\n",
-    "plt.xlabel('pixel')\n",
-    "plt.ylabel('pixel')\n",
-    "plt.title(r\"background-subtracted standard exposure ($T_\\mathrm{exp} = 1\\,\\mathrm{s}$)\");"
+    "We subtract the background (scaled to the exposure time of the standard exposure) and rectify."
    ]
   },
   {
@@ -620,19 +611,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xmin, xmax = 975, 1075\n",
+    "std_result[1].data -= bgresult[1].data / exptime\n",
+    "std_rectified = tracelist.rectify_traces(std_result, -4, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(15, 7))\n",
+    "plt.imshow(std_rectified[1].data, origin='lower', norm=LogNorm(),\n",
+    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
+    "plt.ylabel(r\"position along slit [arcsec]\")\n",
+    "plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
+    "plt.title(\"Standard star\");\n",
+    "plt.colorbar();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xmin, xmax = 675, 825\n",
     "xaxis = np.arange(xmin, xmax)\n",
-    "y_1, y_2 = 200, 1799\n",
+    "y_1, y_2 = 200, 1750\n",
     "lam_1, lam_2 = det_wave[y_1], det_wave[y_2]\n",
     "\n",
     "plt.figure(figsize=(10, 5))\n",
-    "plt.plot(xaxis, std_bgsub[200, xmin:xmax], label=fr\"$\\lambda = {lam_1.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
-    "plt.plot(xaxis, std_bgsub[1800, xmin:xmax], label=fr\"$\\lambda = {lam_2.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
-    "plt.plot(xaxis, std_bgsub[:, xmin:xmax].mean(axis=0), label='average')\n",
-    "plt.vlines((1024 - 10, 1024 + 10), 1, 1e5, colors='black', linestyles='dashed', label='extraction aperture')\n",
+    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_1], label=fr\"$\\lambda = {lam_1.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
+    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_2], label=fr\"$\\lambda = {lam_2.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
+    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, :].mean(axis=1), label='average')\n",
+    "plt.vlines((732 - 10, 732 + 10), 1, 1e5, colors='black', linestyles='dashed', label='extraction aperture')\n",
     "plt.xlabel(\"pixel\")\n",
     "plt.ylabel(\"e/s\")\n",
     "plt.semilogy()\n",
+    "plt.ylim(10, 4e6)\n",
     "plt.legend()\n",
     "plt.title(\"spatial cuts through standard spectrum\");"
    ]
@@ -651,6 +668,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "print(metis['slit_wheel'].current_slit)\n",
     "# TODO: This used to return \"C-38_1\". The headers are made ESO\n",
     "#       Compliant, and not all headers have been replaced.\n",
     "#       See https://github.com/AstarVienna/irdb/pull/146\n",
@@ -671,7 +689,7 @@
    "outputs": [],
    "source": [
     "hwidth = 10     # pixels, half width of extraction aperture\n",
-    "std_1d = std_bgsub[:, 1024-hwidth:1024+hwidth].sum(axis=1)"
+    "std_1d = std_rectified[1].data[731-hwidth:731+hwidth].sum(axis=0)"
    ]
   },
   {
@@ -680,11 +698,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plt.plot(det_wave, std_1d)\n",
-    "# plt.xlabel('Wavelength (um)')\n",
-    "# exptime = std_result[1].header['EXPTIME']\n",
-    "# plt.ylabel('electrons/s')\n",
-    "# plt.title(r\"Extracted standard spectrum ($T_{\\mathrm{exp}} = 1\\,\\mathrm{s}$)\");"
+    "plt.plot(det_wave, std_1d)\n",
+    "plt.xlabel('Wavelength (um)')\n",
+    "exptime = std_rectified[0].header['EXPTIME']\n",
+    "plt.ylabel('electrons/s')\n",
+    "plt.title(r\"Extracted standard spectrum ($T_{\\mathrm{exp}} = 1\\,\\mathrm{s}$)\");"
    ]
   },
   {
@@ -700,12 +718,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# flux_conv = 1 * u.Jy / (std_1d * u.electron)\n",
-    "# plt.plot(det_wave, flux_conv)\n",
-    "# plt.ylim(0, 1e-5)\n",
-    "# plt.xlabel(\"Wavelength (um)\")\n",
-    "# plt.ylabel(\"Jy / (e/s)\")\n",
-    "# plt.title(\"Flux conversion\");"
+    "flux_conv = 1 * u.Jy / (std_1d * u.electron)\n",
+    "plt.plot(det_wave, flux_conv)\n",
+    "plt.ylim(0, 1e-5)\n",
+    "plt.xlabel(\"Wavelength (um)\")\n",
+    "plt.ylabel(\"Jy / (e/s)\")\n",
+    "plt.title(\"Flux conversion\");"
    ]
   },
   {
@@ -721,8 +739,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# emptycav_Jy     = flux_conv[:, None] * (results['emptycav'][1].data - bgresult[1].data) / exptime\n",
-    "# emptycav_Jy_rot = flux_conv[:, None] * (rotresults['emptycav'][1].data - bgresult[1].data) / exptime"
+    "emptycav_Jy     = flux_conv * rectified['emptycav'][1].data / exptime\n",
+    "emptycav_Jy_rot = flux_conv * rotrectified['emptycav'][1].data / exptime"
    ]
   },
   {
@@ -731,22 +749,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(13, 12))\n",
-    "# ax1.imshow(emptycav_Jy[jlim[0]:jlim[1], ilim[0]:ilim[1]].value, origin='lower', \n",
-    "#            norm=LogNorm(vmin=1e-5, vmax=1), extent=(xlim[0], xlim[1], ylim[0], ylim[1]), aspect='auto')\n",
-    "# ax1.set_xlabel(r\"position along slit [arcsec]\")\n",
-    "# ax1.set_ylabel(r\"Wavelength [$\\mu$m]\") \n",
-    "# ax1.set_title(model + \", no rotation\")\n",
+    "plt.imshow(emptycav_Jy.value)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1, figsize=(13, 12))\n",
+    "ax1.imshow(emptycav_Jy.value, origin='lower', \n",
+    "           norm=LogNorm(vmin=1e-5, vmax=1), \n",
+    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
+    "ax1.set_ylabel(r\"position along slit [arcsec]\")\n",
+    "ax1.set_xlabel(r\"Wavelength [$\\mu$m]\") \n",
+    "ax1.set_title(model + \", no rotation\")\n",
     "\n",
-    "# img = ax2.imshow(emptycav_Jy_rot[jlim[0]:jlim[1], ilim[0]:ilim[1]].value, origin='lower',\n",
-    "#                  norm=LogNorm(vmin=1e-5, vmax=1), extent=(xlim[0], xlim[1], ylim[0], ylim[1]), aspect='auto')\n",
-    "# ax2.set_xlabel(r\"position along slit [arcsec]\")\n",
-    "# ax2.set_ylabel(r\"Wavelength [$\\mu$m]\") \n",
-    "# ax2.set_title(model + \", rotated by \" + str(angle) + \" degrees\");\n",
+    "img = ax2.imshow(emptycav_Jy_rot.value, origin='lower',\n",
+    "                 norm=LogNorm(vmin=1e-5, vmax=1), \n",
+    "                 extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
+    "ax2.set_ylabel(r\"position along slit [arcsec]\")\n",
+    "ax2.set_xlabel(r\"Wavelength [$\\mu$m]\") \n",
+    "ax2.set_title(model + \", rotated by \" + str(angle) + \" degrees\");\n",
     "\n",
-    "# fig.subplots_adjust(right=0.8)\n",
-    "# cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
-    "# fig.colorbar(img, cax=cbar_ax, label='Jy')"
+    "fig.subplots_adjust(right=0.8)\n",
+    "cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
+    "fig.colorbar(img, cax=cbar_ax, label='Jy')"
    ]
   },
   {
@@ -762,21 +791,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for i, (model, result) in enumerate(results.items()):\n",
-    "#     result[1].data = flux_conv[:, None].value * (result[1].data - bgresult[1].data) / exptime\n",
-    "#     result[1].header['BUNIT'] = \"e/s\"\n",
-    "#     outfile = (Path(fitsfiles[model]).stem + \"-simulated_LSS_L-bgsub_fluxcal\" \n",
-    "#                + Path(fitsfiles[model]).suffix)\n",
-    "#     result.writeto(outfile, overwrite=True)\n",
-    "#     print(\"--->\", outfile)\n",
+    "# Change to True if you want to save the calibrated data\n",
+    "save_calibrated = False\n",
+    "for i, (model, result) in enumerate(rectified.items()):\n",
+    "    result[1].data = flux_conv.value * result[1].data / exptime\n",
+    "    result[1].header['BUNIT'] = \"e/s\"\n",
+    "    if save_calibrated:\n",
+    "        outfile = (Path(fitsfiles[model]).stem + \"-simulated_LSS_L-bgsub_fluxcal\" \n",
+    "                   + Path(fitsfiles[model]).suffix)\n",
+    "        result.writeto(outfile, overwrite=True)\n",
+    "        print(\"--->\", outfile)\n",
     "\n",
-    "# for i, (model, result) in enumerate(rotresults.items()):\n",
-    "#     result[1].data = flux_conv[:, None].value * (result[1].data - bgresult[1].data) / exptime\n",
-    "#     result[1].header['BUNIT'] = \"e/s\"\n",
-    "#     outfile = (Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) \n",
-    "#                + \"-simulated_LSS_L-bgsub_fluxcal\" + Path(fitsfiles[model]).suffix)\n",
-    "#     result.writeto(outfile, overwrite=True)\n",
-    "#     print(\"--->\", outfile)"
+    "for i, (model, result) in enumerate(rotrectified.items()):\n",
+    "    result[1].data = flux_conv.value * result[1].data / exptime\n",
+    "    result[1].header['BUNIT'] = \"e/s\"\n",
+    "    if save_calibrated:\n",
+    "        outfile = (Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) \n",
+    "                   + \"-simulated_LSS_L-bgsub_fluxcal\" + Path(fitsfiles[model]).suffix)\n",
+    "        result.writeto(outfile, overwrite=True)\n",
+    "        print(\"--->\", outfile)"
    ]
   },
   {
@@ -792,7 +825,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_extract = results['emptycav'][1].data[:, 1018:1030].sum(axis=1)"
+    "result_extract = rectified['emptycav'][1].data[731-hwidth:731+hwidth].sum(axis=0)"
    ]
   },
   {
@@ -811,19 +844,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plt.figure(figsize=(12, 6))\n",
-    "# plt.plot(det_wave, result_extract, label=\"flux-calibrated simulated spectrum\")\n",
-    "# plt.plot(src_wave, src_extract, label=\"input spectrum\")\n",
-    "# plt.legend()\n",
-    "# plt.xlim(3.1, 4.0);"
+    "plt.figure(figsize=(12, 6))\n",
+    "plt.plot(det_wave, result_extract, label=\"flux-calibrated simulated spectrum\")\n",
+    "# The scaling for the source spectrum has been estimated by eye\n",
+    "plt.plot(src_wave, src_extract * 1500, label=\"input spectrum\")\n",
+    "plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
+    "plt.ylabel(\"Relative flux\")\n",
+    "plt.legend()\n",
+    "plt.xlim(3.1, 4.0);"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -113,8 +113,8 @@
    "source": [
     "The file headers are not yet in the form that Scopesim understands and we make two minor modifications: \n",
     "- Set CRVAL to 0, because Scopesim cannot look elsewhere\n",
-    "- Set BUNIT keyword (files have UNITS, which is non-standard)\n",
-    "- The cubes contain the occasional negative value. We replace these with 0.\n",
+    "- Set BUNIT keyword (the files have the keyword UNITS, which is non-standard)\n",
+    "- The cubes contain some negative values. We replace these with 0.\n",
     "- We introduce a factor `scale_delt` to increase the pixel size, which makes features more visible. If you want to simulate the original source pixel scale, set `scale_delt` to 1."
    ]
   },
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "sources = {}\n",
-    "scale_cdelt = 1\n",
+    "scale_cdelt = 5.\n",
     "for model, fitsfile in fitsfiles.items():\n",
     "    with fits.open(fitsfile) as hdul:\n",
     "        hdul[0].header['CRVAL1'] = 0.\n",
@@ -150,7 +150,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Determine plot limits in arcsec from header keywords\n",
+    "# Determine plot limits in arcsec from header keywords (these are in degrees)\n",
     "hdr = sources['cav'].cube_fields[0].header\n",
     "i_lim = np.array([0, hdr['NAXIS1']])\n",
     "x_lim = hdr['CRVAL1'] + hdr['CDELT1'] * (i_lim + 1 - hdr['CRPIX1']) * 3600\n",
@@ -197,7 +197,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The cubes are observed in the long-slit spectroscopic mode in the L band. As usual, there are four steps: `UserCommands` -> `OpticalTrain` -> `observe` -> `readout` to arrive at a detector image. The optical train can be reused for observation of different source when `update=True` is set in `observe()`. "
+    "The cubes are observed in the long-slit spectroscopic mode in the L band. As usual, there are four steps: `UserCommands` -> `OpticalTrain` -> `observe` -> `readout` to arrive at a detector image. The optical train can be reused for observation of different sources when `update=True` is set in `observe()`. \n",
+    "\n",
+    "The simulation uses the `AutoExposure` effect to break down the requested exposure time into `NDIT` subexposures of integration time `DIT` so as to prevent saturation. For this to work, the parameters `dit` and `ndit` currently have to be set to `None` explicitly (here and in every `readout` command below). This will hopefully change in future versions of Scopesim."
    ]
   },
   {
@@ -208,9 +210,7 @@
    "source": [
     "exptime = 3600.   # seconds\n",
     "cmd = sim.UserCommands(use_instrument=\"METIS\", set_modes=[\"lss_l\"],\n",
-    "                      properties={\"!OBS.exptime\": exptime,\n",
-    "                                 \"!SIM.spectral.spectral_resolution\": 20000,\n",
-    "                                 \"!SIM.spectral.spectral_bin_width\": 2e-4})"
+    "                       properties={\"!OBS.exptime\": exptime, \"!OBS.dit\": None, \"!OBS.ndit\": None})"
    ]
   },
   {
@@ -223,6 +223,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Raw METIS data will be stored as unsigned integer. For the purposes of this notebook, this is not required and it will be simpler to deal with real data. We therefore switch the `Quantization` effect off."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metis['quantization'].include = False"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -232,7 +248,7 @@
     "for model, src in sources.items():\n",
     "    print(f'Observing model \"{model}...\"')\n",
     "    metis.observe(src, update=True)\n",
-    "    results[model] = metis.readout(detector_readout_mode='auto')[0]\n",
+    "    results[model] = metis.readout(detector_readout_mode='auto', dit=None, ndit=None)[0]\n",
     "    print(\"-----\")"
    ]
   },
@@ -266,14 +282,14 @@
    "source": [
     "sky = sim.source.source_templates.empty_sky()\n",
     "metis.observe(sky, update=True)\n",
-    "bgresult = metis.readout(detector_readout_mode=\"auto\")[0]"
+    "bgresult = metis.readout(detector_readout_mode=\"auto\", dit=None, ndit=None)[0]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**NEW**: subtract bgresult from all results. Use rectify on results. Rectified spectra have WCS that can be used to display as before."
+    "We subtract the background from the data before rectifying the spectra. Here's where the quantization effect would have caused problems: background subtraction from noisy data leads to negative values, which cannot be represented by unsigned integers and would wrap around to large positive values (in `uint16`: $1 - 2 = 2^{16} - 1 = 65535$). Therefore the data would have to be converted to `float` before proceeding further."
    ]
   },
   {
@@ -284,6 +300,13 @@
    "source": [
     "for (_, result) in results.items():\n",
     "    result[1].data -= bgresult[1].data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now use the `rectify_traces` method to resample the spectra to a linear grid in wavelength and spatial position. The method is attached to the `SpectraTraceList` effect, which holds the information on the geometrical mapping onto the detector. Note that this is an optimistic approach as it uses the same transformations used before to simulate the detector data. When reducing real data, the transformation parameters would have to be estimated from dedicated calibration measurements and would therefore have a degree of uncertainty."
    ]
   },
   {
@@ -335,7 +358,8 @@
     "               extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
     "    plt.ylabel(r\"position along slit [arcsec]\")\n",
     "    plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
-    "    plt.title(model);"
+    "    plt.title(model);\n",
+    "    plt.colorbar()"
    ]
   },
   {
@@ -351,26 +375,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# from pathlib import Path\n",
-    "# for i, (model, result) in enumerate(results.items()):\n",
-    "#     outfile = Path(fitsfiles[model]).stem + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
-    "#     result.writeto(outfile, overwrite=True)\n",
-    "#     print(fitsfiles[model], \"--->\", outfile)\n",
-    "# bgresult.writeto(\"models_Lband_HD100546-background_simulated_LSS_L.fits\", overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Note on the spectral mapping\n",
-    "To use the true spectral mapping of METIS, the trace file has to be set before building the optical train, for example by setting `\"!OBS.trace_file\"` in the `UserCommands`:  \n",
-    "```python\n",
-    "cmd = sim.UserCommands(use_instrument=\"METIS\", set_modes=[\"lss_l\"],\n",
-    "                      properties={\"!OBS.exptime\": 3600,\n",
-    "                                  \"!OBS.trace_file\": \"TRACE_LSS_L.fits\"})\n",
-    "```\n",
-    "For the METIS long-slit mode, the non-linear parts of the actual mapping are quite small.  "
+    "# Change to True if you want to save the rectified data\n",
+    "save_rectified = False\n",
+    "if save_rectified:\n",
+    "    from pathlib import Path\n",
+    "    for i, (model, result) in enumerate(rectified.items()):\n",
+    "        outfile = Path(fitsfiles[model]).stem + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
+    "        result.writeto(outfile, overwrite=True)\n",
+    "        print(fitsfiles[model], \"--->\", outfile)\n",
+    "    bgresult.writeto(\"models_Lband_HD100546-background_simulated_LSS_L.fits\", overwrite=True)"
    ]
   },
   {
@@ -433,7 +446,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function is applied to the data cubes before creating the `Source` object. We choose an angle of 45 degrees. The simulation the proceeds as above."
+    "The function is applied to the data cubes before creating the `Source` object. We choose an angle of 45 degrees. The simulation then proceeds as above."
    ]
   },
   {
@@ -466,7 +479,7 @@
     "for model, src in rotsources.items():\n",
     "    print(f'Observing model \"{model}\"...')\n",
     "    metis.observe(src, update=True)\n",
-    "    rotresults[model] = metis.readout(detector_readout_mode='auto')[0]\n",
+    "    rotresults[model] = metis.readout(detector_readout_mode='auto', dit=None, ndit=None)[0]\n",
     "    print(\"-----\")"
    ]
   },
@@ -476,15 +489,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# plt.figure(figsize=(15, 8))\n",
-    "# for i, (model, result) in enumerate(rotresults.items()):\n",
-    "#     plt.subplot(1, 3, i+1)\n",
-    "#     plt.imshow((result[1].data - bgresult[1].data)[jlim[0]:jlim[1], ilim[0]:ilim[1]], \n",
-    "#                origin='lower', norm=LogNorm(),\n",
-    "#                extent=(xlim[0], xlim[1], ylim[0], ylim[1]), aspect='auto')\n",
-    "#     plt.xlabel(r\"position along slit [arcsec]\")\n",
-    "#     plt.ylabel(r\"Wavelength [$\\mu$m]\")\n",
-    "#     plt.title(model + \", rotated by \" + str(angle) + \" degrees\")"
+    "rotrectified = {}\n",
+    "for model, result in rotresults.items():\n",
+    "    result[1].data -= bgresult[1].data\n",
+    "    rotrectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)"
    ]
   },
   {
@@ -493,10 +501,30 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for i, (model, result) in enumerate(rotresults.items()):\n",
-    "#     outfile = Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
-    "#     result.writeto(outfile, overwrite=True)\n",
-    "#     print(fitsfiles[model], \"--->\", outfile)"
+    "plt.figure(figsize=(15, 15))\n",
+    "for i, (model, result) in enumerate(rotrectified.items()):\n",
+    "    plt.subplot(3, 1, i+1)\n",
+    "    plt.imshow(result[1].data, origin='lower', norm=LogNorm(),\n",
+    "               extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
+    "    plt.ylabel(r\"position along slit [arcsec]\")\n",
+    "    plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
+    "    plt.title(model);\n",
+    "    plt.colorbar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change to True if you want to save the rectified data\n",
+    "save_rotrectified = False\n",
+    "if (save_rotrectified):\n",
+    "    for i, (model, result) in enumerate(rotresults.items()):\n",
+    "        outfile = Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
+    "        result.writeto(outfile, overwrite=True)\n",
+    "        print(fitsfiles[model], \"--->\", outfile)"
    ]
   },
   {
@@ -512,21 +540,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1, figsize=(6, 12))\n",
+    "fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1, figsize=(6, 12))\n",
     "\n",
-    "# ax1.plot(det_xi, (results['emptycav'][1].data - bgresult[1].data)[500, :], label=\"no rotation\")\n",
-    "# ax1.plot(det_xi, (rotresults['emptycav'][1].data - bgresult[1].data)[500, :], label=f\"rotation {angle} deg\")\n",
-    "# ax1.set_xlim(xlim[0], xlim[-1])\n",
-    "# ax1.set_ylim(2e4, 1e9)\n",
-    "# ax1.set_xlabel(\"arcsec\")\n",
-    "# ax1.semilogy()\n",
-    "# ax1.legend()\n",
+    "ax1.plot(det_xi, rectified['emptycav'][1].data[:, 1500], label=\"no rotation\")\n",
+    "ax1.plot(det_xi, rotrectified['emptycav'][1].data[:, 1500], label=f\"rotation {angle} deg\")\n",
+    "ax1.set_xlim(x_lim[0], x_lim[-1])\n",
+    "ax1.set_ylim(2e4, 1e9)\n",
+    "ax1.set_xlabel(\"arcsec\")\n",
+    "ax1.semilogy()\n",
+    "ax1.legend()\n",
     "\n",
-    "# fig.subplots_adjust(left=0.1)\n",
-    "# ax2.imshow(rotsources['emptycav'].cube_fields[0].data.sum(axis=0) + 1e-14, norm=LogNorm(vmin=1e-4, vmax=10),\n",
-    "#           extent=(x_lim[0], x_lim[-1], y_lim[0], y_lim[-1]))\n",
-    "# ax2.set_xlabel(\"arcsec\")\n",
-    "# ax2.set_ylabel(\"arcsec\")"
+    "fig.subplots_adjust(left=0.1)\n",
+    "ax2.imshow(rotsources['emptycav'].cube_fields[0].data.sum(axis=0) + 1e-14, norm=LogNorm(vmin=1e-4, vmax=10),\n",
+    "           extent=(x_lim[0], x_lim[-1], y_lim[0], y_lim[-1]))\n",
+    "ax2.set_xlabel(\"arcsec\")\n",
+    "ax2.set_ylabel(\"arcsec\")"
    ]
   },
   {
@@ -568,7 +596,7 @@
    "outputs": [],
    "source": [
     "std_exptime = 1  # second\n",
-    "std_result = metis.readout(exptime=std_exptime, detector_readout_mode='auto')[0]"
+    "std_result = metis.readout(exptime=std_exptime, detector_readout_mode='auto', dit=None, ndit=None)[0]"
    ]
   },
   {
@@ -592,21 +620,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# xmin, xmax = 975, 1075\n",
-    "# xaxis = np.arange(xmin, xmax)\n",
-    "# y_1, y_2 = 200, 1800\n",
-    "# lam_1, lam_2 = det_wave[y_1], det_wave[y_2]\n",
+    "xmin, xmax = 975, 1075\n",
+    "xaxis = np.arange(xmin, xmax)\n",
+    "y_1, y_2 = 200, 1799\n",
+    "lam_1, lam_2 = det_wave[y_1], det_wave[y_2]\n",
     "\n",
-    "# plt.figure(figsize=(10, 5))\n",
-    "# plt.plot(xaxis, std_bgsub[200, xmin:xmax], label=fr\"$\\lambda = {lam_1:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
-    "# plt.plot(xaxis, std_bgsub[1800, xmin:xmax], label=fr\"$\\lambda = {lam_2:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
-    "# plt.plot(xaxis, std_bgsub[:, xmin:xmax].mean(axis=0), label='average')\n",
-    "# plt.vlines((1024 - 10, 1024 + 10), 1, 1e5, colors='black', linestyles='dashed', label='extraction aperture')\n",
-    "# plt.xlabel(\"pixel\")\n",
-    "# plt.ylabel(\"e/s\")\n",
-    "# plt.semilogy()\n",
-    "# plt.legend()\n",
-    "# plt.title(\"spatial cuts through standard spectrum\");"
+    "plt.figure(figsize=(10, 5))\n",
+    "plt.plot(xaxis, std_bgsub[200, xmin:xmax], label=fr\"$\\lambda = {lam_1.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
+    "plt.plot(xaxis, std_bgsub[1800, xmin:xmax], label=fr\"$\\lambda = {lam_2.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
+    "plt.plot(xaxis, std_bgsub[:, xmin:xmax].mean(axis=0), label='average')\n",
+    "plt.vlines((1024 - 10, 1024 + 10), 1, 1e5, colors='black', linestyles='dashed', label='extraction aperture')\n",
+    "plt.xlabel(\"pixel\")\n",
+    "plt.ylabel(\"e/s\")\n",
+    "plt.semilogy()\n",
+    "plt.legend()\n",
+    "plt.title(\"spatial cuts through standard spectrum\");"
    ]
   },
   {
@@ -626,7 +654,7 @@
     "# TODO: This used to return \"C-38_1\". The headers are made ESO\n",
     "#       Compliant, and not all headers have been replaced.\n",
     "#       See https://github.com/AstarVienna/irdb/pull/146\n",
-    "# std_result[1].header['SLIT']"
+    "#std_result[0].header"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {


### PR DESCRIPTION
This deals with  Issue #173. 

METIS now uses by default the full non-linear spectral mappings for LSS simulations. The notebook `LSS-YSO_model_simulation.ipynb` relied on the use of the linear "science" mappings for plotting, this now necessitates an explicit rectification of the simulation results.

Currently, rectification is done as a proof of concept for the first simulation. This needs to be expanded and the notebook cleaned up before merging.