### PR TITLE
Fix downloads in notebooks

### DIFF
--- a/METIS/docs/example_notebooks/IMG_L_N-examples.ipynb
+++ b/METIS/docs/example_notebooks/IMG_L_N-examples.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.download_example_data([\"HL_Tau_prep_for_Scopesim.fits\", \"AGN_uc0890_image_l12_i090_p000.fits\"])"
+    "paths = sim.download_example_data(\"HL_Tau_prep_for_Scopesim.fits\", \"AGN_uc0890_image_l12_i090_p000.fits\")"
    ]
   },
   {
@@ -103,7 +103,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_hdul = fits.open(\"HL_Tau_prep_for_Scopesim.fits\")"
+    "input_hdul = fits.open(paths[0])"
    ]
   },
   {
@@ -154,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,20 +170,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Lp'"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "cmd_l[\"!OBS.filter_name\"]"
    ]
@@ -209,7 +198,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -311,7 +300,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "input_hdul = fits.open(\"AGN_uc0890_image_l12_i090_p000.fits\")"
+    "input_hdul = fits.open(paths[1])"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/IMG_L_N-examples.ipynb
+++ b/METIS/docs/example_notebooks/IMG_L_N-examples.ipynb
@@ -64,7 +64,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package(['instruments/METIS', 'telescopes/ELT', 'locations/Armazones'])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {
@@ -579,7 +579,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -593,7 +593,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -104,7 +104,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim.download_example_data(list(fitsfiles.values()))"
+    "fitsfiles = dict(zip(fitsfiles, sim.download_example_data(*fitsfiles.values())))"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/LSS_AGN-01_preparation.ipynb
+++ b/METIS/docs/example_notebooks/LSS_AGN-01_preparation.ipynb
@@ -60,7 +60,7 @@
     "fitsfile = \"tor_oa20_t9-5sg_Rout1.5_Rin0.13_p0__hypSh_oa40-50_tV-0.01g_D40_a0.2-0.4_tlt0_i90_total.fits\"\n",
     "sedfile = \"tor_oa20_t9-5sg_Rout1.5_Rin0.13_p0__hypSh_oa40-50_tV-0.01g_D40_a0.2-0.4_tlt0_i90_sed.dat\"\n",
     "\n",
-    "sim.download_example_data([fitsfile, sedfile])"
+    "fitsfile, sedfile = sim.download_example_data(fitsfile, sedfile)"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/LSS_AGN-02_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS_AGN-02_simulation.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# sim.download_package([\"instruments/METIS\", \"telescopes/ELT\", \"locations/Armazones\"])"
+    "# sim.download_packages([\"METIS\", \"ELT\", \"Armazones\"])"
    ]
   },
   {

--- a/MICADO/docs/example_notebooks/3_scopesim_SCAO_4mas_fv-psf.ipynb
+++ b/MICADO/docs/example_notebooks/3_scopesim_SCAO_4mas_fv-psf.ipynb
@@ -21,20 +21,10 @@
    "execution_count": 1,
    "id": "unlimited-cliff",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\ghost\\AppData\\Local\\Temp\\ipykernel_17984\\2683991280.py:10: DeprecationWarning: In a future version top level function calls will be removed. Always use this syntax: from module.submodule import function\n",
-      "  import scopesim_templates as sim_tp\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "import datetime\n",
-    "import shutil\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from matplotlib.colors import LogNorm\n",
@@ -87,7 +77,16 @@
    "execution_count": 2,
    "id": "altered-paris",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[32mimf - sample_imf: Setting maximum allowed mass to 10000\u001b[0m\n",
+      "\u001b[32mimf - sample_imf: Loop 0 added 1.01e+04 Msun to previous total of 0.00e+00 Msun\u001b[0m\n"
+     ]
+    }
+   ],
    "source": [
     "cluster = sim_tp.cluster(mass=10000, core_radius=0.5, distance=8000)"
    ]
@@ -268,12 +267,17 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "5d21be74",
+   "id": "c9b0961b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "from astropy.utils.data import download_file\n",
-    "fname2 = download_file(\"https://scopesim.univie.ac.at/InstPkgSvr/psfs/AnisoCADO_SCAO_FVPSF_4mas_EsoMedian_20190328.fits\", cache=True)"
+    "from pooch import retrieve\n",
+    "fname = retrieve(\n",
+    "    \"https://scopesim.univie.ac.at/InstPkgSvr/psfs/AnisoCADO_SCAO_FVPSF_4mas_EsoMedian_20190328.fits\",\n",
+    "    known_hash=\"a9bd309e5ac025f2aa5f8ded85323465578906e47025ce86501985c9b258474c\",\n",
+    "    fname=\"AnisoCADO_SCAO_FVPSF_4mas_EsoMedian_20190328.fits\",\n",
+    "    progressbar=True,\n",
+    ")"
    ]
   },
   {
@@ -283,8 +287,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fname = \"AnisoCADO_SCAO_FVPSF_4mas_EsoMedian_20190328.fits\"\n",
-    "shutil.copy(fname2, fname)\n",
     "fv_psf = sim.effects.psfs.FieldVaryingPSF(filename=fname, name=\"SCAO_FV_PSF\")"
    ]
   },


### PR DESCRIPTION
Following AstarVienna/ScopeSim#446.

For the PSF download in MICADO, we might eventually expand the download facilities in ScopeSim, once `pooch` has proven to be (more) stable. For now, I used pooch's "script mode" to move AstarVienna/ScopeSim#332 forward.