### PR TITLE
Further clean up YSO notebook, apply units consistently

### DIFF
--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -74,7 +74,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The input data are cubes of three different models of the same YSO, HD100546. We keep the names of FITS files, the `Source` objects and the results of the Scopesim simulations in dictionaries, indexed by short names for the models."
+    "The input data are cubes of three different models of the same YSO, HD100546. We keep the names of FITS files, the `Source` objects and the results of the ScopeSim simulations in dictionaries, indexed by short names for the models."
    ]
   },
   {
@@ -95,7 +95,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The FITS files can be downloaded from the Scopesim server. If you already have them, make sure that the files are in the current working directory."
+    "The FITS files can be downloaded from the ScopeSim server. If you already have them, make sure that the files are in the correct location (e.g. current working directory, see also the note below). The next code cell will replace the file names with absolute paths to the download cache location. If you already have the files in the current working directory, simply skip that line and ScopeSim will look for them there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    <b>Note:</b> ScopeSim v0.9.0 or later will now download the example data to a hidden cache directory by default. To change this, pass the optional <tt>save_dir</tt> argument to <tt>sim.download_example_data()</tt> with the desired download location, e.g. <tt>save_dir=\"./\"</tt> for the current working directory (the default download location in previous versions).\n",
+    "</div>"
    ]
   },
   {
@@ -111,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The file headers are not yet in the form that Scopesim understands and we make two minor modifications: \n",
+    "The file headers are not yet in the form that ScopeSim understands and we make two minor modifications: \n",
     "- Set CRVAL to 0, because Scopesim cannot look elsewhere\n",
     "- Set BUNIT keyword (the files have the keyword UNITS, which is non-standard)\n",
     "- The cubes contain some negative values. We replace these with 0.\n",

--- a/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS-YSO_model_simulation.ipynb
@@ -83,12 +83,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fitsfiles = {}\n",
-    "fitsfiles['cav'] = \"models_Lband_HD100546_cav_f100PAH.cube_3.0mas.fits\"\n",
-    "fitsfiles['emptycav'] = \"models_Lband_HD100546_empytcav.cube_3.0mas.fits\"\n",
-    "fitsfiles['gap'] = \"models_Lband_HD100546_gap100.cube_3.0mas.fits\"\n",
-    "models = list(fitsfiles.keys())\n",
-    "print(\"Model names:\", models)"
+    "fitsfiles = {\n",
+    "    \"cav\": \"models_Lband_HD100546_cav_f100PAH.cube_3.0mas.fits\",\n",
+    "    \"emptycav\": \"models_Lband_HD100546_empytcav.cube_3.0mas.fits\",\n",
+    "    \"gap\": \"models_Lband_HD100546_gap100.cube_3.0mas.fits\",\n",
+    "}\n",
+    "print(\"Model names:\", list(fitsfiles))"
    ]
   },
   {
@@ -133,7 +133,7 @@
     "        hdul[0].header['CDELT1'] *= scale_cdelt\n",
     "        hdul[0].header['CDELT2'] *= scale_cdelt\n",
     "        hdul[0].header['BUNIT'] = hdul[0].header['UNITS']\n",
-    "        hdul[0].data[hdul[0].data < 0] = 0\n",
+    "        hdul[0].data.clip(min=0, out=hdul[0].data)\n",
     "        sources[model] = sim.Source(cube=hdul)"
    ]
   },
@@ -160,7 +160,7 @@
     "fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(15, 4))\n",
     "for i, (model, src) in enumerate(sources.items()):\n",
     "    im = axes[i].imshow(src.cube_fields[0].data.sum(axis=0) + 1e-14,   # add small positive value to avoid 0 in LogNorm\n",
-    "                        origin='lower', norm=LogNorm(vmin=1e-4, vmax=10),\n",
+    "                        origin=\"lower\", norm=\"log\", vmin=1e-4, vmax=10,\n",
     "                        extent=(x_lim[0], x_lim[-1], y_lim[0], y_lim[-1]))\n",
     "    axes[i].set_xlabel(\"arcsec\")\n",
     "    axes[i].set_ylabel(\"arcsec\")\n",
@@ -215,9 +215,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "exptime = 3600.   # seconds\n",
+    "exptime = 3600 * u.s\n",
     "cmd = sim.UserCommands(use_instrument=\"METIS\", set_modes=[\"lss_l\"],\n",
-    "                       properties={\"!OBS.exptime\": exptime, \"!OBS.dit\": None, \"!OBS.ndit\": None})"
+    "                       properties={\"!OBS.exptime\": exptime.value, \"!OBS.dit\": None, \"!OBS.ndit\": None})"
    ]
   },
   {
@@ -240,6 +240,7 @@
     "    print(f'Observing model \"{model}...\"')\n",
     "    metis.observe(src, update=True)\n",
     "    results[model] = metis.readout(detector_readout_mode='auto', dit=None, ndit=None)[0]\n",
+    "    results[model][1].data <<= u.electron  # Apply unit\n",
     "    print(\"-----\")"
    ]
   },
@@ -249,13 +250,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(15, 5))\n",
-    "for i, (model, result) in enumerate(results.items()):\n",
-    "    plt.subplot(1, 3, i+1)\n",
-    "    plt.imshow(result[1].data, origin='lower', norm=LogNorm())\n",
-    "    plt.xlabel(\"pixel\")\n",
-    "    plt.ylabel(\"pixel\")\n",
-    "    plt.title(model);"
+    "fig, axes = plt.subplots(nrows=1, ncols=3, figsize=(15, 5.2))\n",
+    "for axis, (model, result) in zip(axes, results.items()):\n",
+    "    axis.imshow(result[1].data.value, origin=\"lower\", norm=\"log\")\n",
+    "    axis.set_xlabel(\"pixel\")\n",
+    "    axis.set_ylabel(\"pixel\")\n",
+    "    axis.set_title(model)\n",
+    "fig.suptitle(\"Raw spectra\", fontsize=20);"
    ]
   },
   {
@@ -273,7 +274,8 @@
    "source": [
     "sky = sim.source.source_templates.empty_sky()\n",
     "metis.observe(sky, update=True)\n",
-    "bgresult = metis.readout(detector_readout_mode=\"auto\", dit=None, ndit=None)[0]"
+    "bgresult = metis.readout(detector_readout_mode=\"auto\", dit=None, ndit=None)[0]\n",
+    "bgresult[1].data <<= u.electron  # Apply unit"
    ]
   },
   {
@@ -289,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for (_, result) in results.items():\n",
+    "for result in results.values():\n",
     "    result[1].data -= bgresult[1].data"
    ]
   },
@@ -308,8 +310,9 @@
    "source": [
     "rectified = {}\n",
     "tracelist = metis['spectral_traces']\n",
-    "for i, (model, result) in enumerate(results.items()):\n",
-    "    rectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)"
+    "for model, result in results.items():\n",
+    "    rectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)\n",
+    "    rectified[model][1].data <<= u.electron  # Apply unit"
    ]
   },
   {
@@ -329,11 +332,8 @@
     "hdr = rectified['cav'][1].header\n",
     "wcs = WCS(hdr)\n",
     "naxis1, naxis2 = hdr['NAXIS1'], hdr['NAXIS2']\n",
-    "det_xi = wcs.all_pix2world(1, np.arange(naxis2), 0)[1] * u.Unit(wcs.wcs.cunit[1])\n",
-    "det_xi = det_xi.to(u.arcsec)\n",
-    "\n",
-    "det_wave = wcs.all_pix2world(np.arange(naxis1), 1, 0)[0] * u.Unit(wcs.wcs.cunit[0])\n",
-    "det_wave = det_wave.to(u.um)          "
+    "det_xi = wcs.sub((2,)).pixel_to_world(np.arange(naxis2)).to(u.arcsec)\n",
+    "det_wave = wcs.spectral.pixel_to_world(np.arange(naxis1)).to(u.um)        "
    ]
   },
   {
@@ -342,15 +342,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(15, 15))\n",
-    "for i, (model, result) in enumerate(rectified.items()):\n",
-    "    plt.subplot(3, 1, i+1)\n",
-    "    plt.imshow(result[1].data, origin='lower', norm=LogNorm(),\n",
-    "               extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
-    "    plt.ylabel(r\"position along slit [arcsec]\")\n",
-    "    plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
-    "    plt.title(model);\n",
-    "    plt.colorbar()"
+    "fig, axes = plt.subplots(nrows=3, ncols=1, figsize=(15, 15))\n",
+    "for axis, (model, result) in zip(axes, rectified.items()):\n",
+    "    img = axis.imshow(\n",
+    "        result[1].data.value, origin=\"lower\", norm=\"log\", aspect=\"auto\",\n",
+    "        extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value))\n",
+    "    axis.set_ylabel(f\"position along slit [{det_xi.unit.to_string('latex')}]\")\n",
+    "    axis.set_xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "    axis.set_title(model);\n",
+    "    fig.colorbar(img, ax=axis)\n",
+    "fig.suptitle(\"Rectified spectra\", y=.99, fontsize=24)\n",
+    "fig.tight_layout()"
    ]
   },
   {
@@ -378,7 +380,7 @@
     "# Change to True if you want to save the rectified data\n",
     "save_rectified = False\n",
     "if save_rectified:\n",
-    "    for i, (model, result) in enumerate(rectified.items()):\n",
+    "    for model, result in rectified.items():\n",
     "        outfile = Path(fitsfiles[model]).stem + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
     "        result.writeto(outfile, overwrite=True)\n",
     "        print(fitsfiles[model], \"--->\", outfile)\n",
@@ -463,7 +465,7 @@
     "        hdul[0].header['CDELT1'] *= scale_cdelt\n",
     "        hdul[0].header['CDELT2'] *= scale_cdelt\n",
     "        hdul[0].header['BUNIT'] = hdul[0].header['UNITS']\n",
-    "        hdul[0].data[hdul[0].data < 0] = 0\n",
+    "        hdul[0].data.clip(min=0, out=hdul[0].data)\n",
     "        hdul[0] = rotate_cube(hdul[0], angle)\n",
     "        rotsources[model] = sim.Source(cube=hdul)"
    ]
@@ -479,6 +481,7 @@
     "    print(f'Observing model \"{model}\"...')\n",
     "    metis.observe(src, update=True)\n",
     "    rotresults[model] = metis.readout(detector_readout_mode='auto', dit=None, ndit=None)[0]\n",
+    "    rotresults[model][1].data <<= u.electron  # Apply unit\n",
     "    print(\"-----\")"
    ]
   },
@@ -491,7 +494,8 @@
     "rotrectified = {}\n",
     "for model, result in rotresults.items():\n",
     "    result[1].data -= bgresult[1].data\n",
-    "    rotrectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)"
+    "    rotrectified[model] = tracelist.rectify_traces(result, -4.0, 4.0)\n",
+    "    rotrectified[model][1].data <<= u.electron  # Apply unit"
    ]
   },
   {
@@ -500,15 +504,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(15, 15))\n",
-    "for i, (model, result) in enumerate(rotrectified.items()):\n",
-    "    plt.subplot(3, 1, i+1)\n",
-    "    plt.imshow(result[1].data, origin='lower', norm=LogNorm(),\n",
-    "               extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
-    "    plt.ylabel(r\"position along slit [arcsec]\")\n",
-    "    plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
-    "    plt.title(model);\n",
-    "    plt.colorbar()"
+    "fig, axes = plt.subplots(nrows=3, ncols=1, figsize=(15, 15))\n",
+    "for axis, (model, result) in zip(axes, rotrectified.items()):\n",
+    "    img = axis.imshow(\n",
+    "        result[1].data.value, origin=\"lower\", norm=\"log\", aspect=\"auto\",\n",
+    "        extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value))\n",
+    "    axis.set_ylabel(f\"position along slit [{det_xi.unit.to_string('latex')}]\")\n",
+    "    axis.set_xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "    axis.set_title(model);\n",
+    "    fig.colorbar(img, ax=axis)\n",
+    "fig.suptitle(\"Rectified rotated spectra\", y=.99, fontsize=24)\n",
+    "fig.tight_layout()"
    ]
   },
   {
@@ -519,9 +525,9 @@
    "source": [
     "# Change to True if you want to save the rectified data\n",
     "save_rotrectified = False\n",
-    "if (save_rotrectified):\n",
-    "    for i, (model, result) in enumerate(rotresults.items()):\n",
-    "        outfile = Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) + \"-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
+    "if save_rotrectified:\n",
+    "    for model, result in rotresults.items():\n",
+    "        outfile = Path(fitsfiles[model]).stem + f\"-rot_{angle}-simulated_LSS_L\" + Path(fitsfiles[model]).suffix\n",
     "        result.writeto(outfile, overwrite=True)\n",
     "        print(fitsfiles[model], \"--->\", outfile)"
    ]
@@ -550,7 +556,8 @@
     "ax1.legend()\n",
     "\n",
     "fig.subplots_adjust(left=0.1)\n",
-    "ax2.imshow(rotsources['emptycav'].cube_fields[0].data.sum(axis=0) + 1e-14, norm=LogNorm(vmin=1e-4, vmax=10),\n",
+    "ax2.imshow(rotsources['emptycav'].cube_fields[0].data.sum(axis=0) + 1e-14,\n",
+    "           norm=\"log\", vmin=1e-4, vmax=10,\n",
     "           extent=(x_lim[0], x_lim[-1], y_lim[0], y_lim[-1]))\n",
     "ax2.set_xlabel(\"arcsec\")\n",
     "ax2.set_ylabel(\"arcsec\")"
@@ -594,8 +601,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "std_exptime = 1  # second\n",
-    "std_result = metis.readout(exptime=std_exptime, detector_readout_mode='auto', dit=None, ndit=None)[0]"
+    "std_exptime = 1 * u.s\n",
+    "std_result = metis.readout(exptime=std_exptime.value, detector_readout_mode='auto', dit=None, ndit=None)[0]\n",
+    "std_result[1].data <<= u.electron"
    ]
   },
   {
@@ -611,8 +619,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "std_result[1].data -= bgresult[1].data / exptime\n",
-    "std_rectified = tracelist.rectify_traces(std_result, -4, 4)"
+    "std_result[1].data -= bgresult[1].data / exptime * std_exptime\n",
+    "std_rectified = tracelist.rectify_traces(std_result, -4, 4)\n",
+    "std_rectified[1].data <<= u.electron"
    ]
   },
   {
@@ -622,11 +631,11 @@
    "outputs": [],
    "source": [
     "plt.figure(figsize=(15, 7))\n",
-    "plt.imshow(std_rectified[1].data, origin='lower', norm=LogNorm(),\n",
-    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
-    "plt.ylabel(r\"position along slit [arcsec]\")\n",
-    "plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
-    "plt.title(\"Standard star\");\n",
+    "plt.imshow(std_rectified[1].data.value, origin=\"lower\", norm=\"log\", aspect=\"auto\",\n",
+    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value))\n",
+    "plt.ylabel(f\"position along slit [{det_xi.unit.to_string('latex')}]\")\n",
+    "plt.xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "plt.title(\"Standard star\")\n",
     "plt.colorbar();"
    ]
   },
@@ -642,16 +651,16 @@
     "lam_1, lam_2 = det_wave[y_1], det_wave[y_2]\n",
     "\n",
     "plt.figure(figsize=(10, 5))\n",
-    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_1], label=fr\"$\\lambda = {lam_1.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
-    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_2], label=fr\"$\\lambda = {lam_2.value:.2f}\\,\\mu\\mathrm{{m}}$\")\n",
+    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_1], label=fr\"$\\lambda = ${lam_1.to_string(precision=3, format='latex')}\")\n",
+    "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, y_2], label=fr\"$\\lambda = ${lam_2.to_string(precision=3, format='latex')}\")\n",
     "plt.plot(xaxis, std_rectified[1].data[xmin:xmax, :].mean(axis=1), label='average')\n",
     "plt.vlines((732 - 10, 732 + 10), 1, 1e5, colors='black', linestyles='dashed', label='extraction aperture')\n",
     "plt.xlabel(\"pixel\")\n",
-    "plt.ylabel(\"e/s\")\n",
+    "plt.ylabel(std_rectified[1].data.unit)\n",
     "plt.semilogy()\n",
     "plt.ylim(10, 4e6)\n",
     "plt.legend()\n",
-    "plt.title(\"spatial cuts through standard spectrum\");"
+    "plt.title(\"Spatial cuts through standard spectrum\");"
    ]
   },
   {
@@ -689,7 +698,8 @@
    "outputs": [],
    "source": [
     "hwidth = 10     # pixels, half width of extraction aperture\n",
-    "std_1d = std_rectified[1].data[731-hwidth:731+hwidth].sum(axis=0)"
+    "# exptime = std_rectified[0].header[\"EXPTIME\"] * u.s\n",
+    "std_1d = std_rectified[1].data[731-hwidth:731+hwidth].sum(axis=0) / std_exptime"
    ]
   },
   {
@@ -699,10 +709,9 @@
    "outputs": [],
    "source": [
     "plt.plot(det_wave, std_1d)\n",
-    "plt.xlabel('Wavelength (um)')\n",
-    "exptime = std_rectified[0].header['EXPTIME']\n",
-    "plt.ylabel('electrons/s')\n",
-    "plt.title(r\"Extracted standard spectrum ($T_{\\mathrm{exp}} = 1\\,\\mathrm{s}$)\");"
+    "plt.xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "plt.ylabel(std_1d.unit)\n",
+    "plt.title(fr\"Extracted standard spectrum ($T_\\mathrm{{exp}} = ${std_exptime.to_string(format='latex')})\");"
    ]
   },
   {
@@ -718,11 +727,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flux_conv = 1 * u.Jy / (std_1d * u.electron)\n",
+    "flux_conv = 1 * u.Jy / std_1d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.plot(det_wave, flux_conv)\n",
     "plt.ylim(0, 1e-5)\n",
-    "plt.xlabel(\"Wavelength (um)\")\n",
-    "plt.ylabel(\"Jy / (e/s)\")\n",
+    "plt.xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "plt.ylabel(flux_conv.unit.to_string(\"latex_inline\"))\n",
     "plt.title(\"Flux conversion\");"
    ]
   },
@@ -739,17 +756,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "emptycav_Jy     = flux_conv * rectified['emptycav'][1].data / exptime\n",
-    "emptycav_Jy_rot = flux_conv * rotrectified['emptycav'][1].data / exptime"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "plt.imshow(emptycav_Jy.value)"
+    "emptycav_Jy     = flux_conv * rectified['emptycav'][1].data * u.electron / exptime\n",
+    "emptycav_Jy_rot = flux_conv * rotrectified['emptycav'][1].data * u.electron / exptime"
    ]
   },
   {
@@ -759,23 +767,21 @@
    "outputs": [],
    "source": [
     "fig, (ax1, ax2) = plt.subplots(nrows=2, ncols=1, figsize=(13, 12))\n",
-    "ax1.imshow(emptycav_Jy.value, origin='lower', \n",
-    "           norm=LogNorm(vmin=1e-5, vmax=1), \n",
-    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
-    "ax1.set_ylabel(r\"position along slit [arcsec]\")\n",
-    "ax1.set_xlabel(r\"Wavelength [$\\mu$m]\") \n",
-    "ax1.set_title(model + \", no rotation\")\n",
+    "ax1.imshow(emptycav_Jy.value, origin=\"lower\", norm=\"log\", vmin=1e-5, vmax=1, aspect=\"auto\",\n",
+    "           extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value))\n",
+    "ax1.set_ylabel(f\"position along slit [{det_xi.unit.to_string('latex')}]\")\n",
+    "ax1.set_xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\")\n",
+    "ax1.set_title(f\"{model}, no rotation\")\n",
     "\n",
-    "img = ax2.imshow(emptycav_Jy_rot.value, origin='lower',\n",
-    "                 norm=LogNorm(vmin=1e-5, vmax=1), \n",
-    "                 extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value), aspect='auto')\n",
-    "ax2.set_ylabel(r\"position along slit [arcsec]\")\n",
-    "ax2.set_xlabel(r\"Wavelength [$\\mu$m]\") \n",
-    "ax2.set_title(model + \", rotated by \" + str(angle) + \" degrees\");\n",
+    "img = ax2.imshow(emptycav_Jy_rot.value, origin=\"lower\", norm=\"log\", vmin=1e-5, vmax=1, aspect=\"auto\", \n",
+    "                 extent=(det_wave[0].value, det_wave[-1].value, det_xi[0].value, det_xi[-1].value))\n",
+    "ax2.set_ylabel(f\"position along slit [{det_xi.unit.to_string('latex')}]\")\n",
+    "ax2.set_xlabel(f\"Wavelength [{det_wave.unit.to_string('latex')}]\") \n",
+    "ax2.set_title(f\"{model}, rotated by {angle} degrees\")\n",
     "\n",
     "fig.subplots_adjust(right=0.8)\n",
     "cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
-    "fig.colorbar(img, cax=cbar_ax, label='Jy')"
+    "fig.colorbar(img, cax=cbar_ax, label=emptycav_Jy_rot.unit);"
    ]
   },
   {
@@ -793,21 +799,21 @@
    "source": [
     "# Change to True if you want to save the calibrated data\n",
     "save_calibrated = False\n",
-    "for i, (model, result) in enumerate(rectified.items()):\n",
+    "for model, result in rectified.items():\n",
     "    result[1].data = flux_conv.value * result[1].data / exptime\n",
     "    result[1].header['BUNIT'] = \"e/s\"\n",
     "    if save_calibrated:\n",
-    "        outfile = (Path(fitsfiles[model]).stem + \"-simulated_LSS_L-bgsub_fluxcal\" \n",
+    "        outfile = (Path(fitsfiles[model]).stem + \"-simulated_LSS_L-bgsub_fluxcal\"\n",
     "                   + Path(fitsfiles[model]).suffix)\n",
     "        result.writeto(outfile, overwrite=True)\n",
     "        print(\"--->\", outfile)\n",
     "\n",
-    "for i, (model, result) in enumerate(rotrectified.items()):\n",
+    "for model, result in rotrectified.items():\n",
     "    result[1].data = flux_conv.value * result[1].data / exptime\n",
     "    result[1].header['BUNIT'] = \"e/s\"\n",
     "    if save_calibrated:\n",
-    "        outfile = (Path(fitsfiles[model]).stem + \"-rot_\" + str(angle) \n",
-    "                   + \"-simulated_LSS_L-bgsub_fluxcal\" + Path(fitsfiles[model]).suffix)\n",
+    "        outfile = (Path(fitsfiles[model]).stem + f\"-rot_{angle}-simulated_LSS_L-bgsub_fluxcal\"\n",
+    "                   + Path(fitsfiles[model]).suffix)\n",
     "        result.writeto(outfile, overwrite=True)\n",
     "        print(\"--->\", outfile)"
    ]
@@ -847,12 +853,20 @@
     "plt.figure(figsize=(12, 6))\n",
     "plt.plot(det_wave, result_extract, label=\"flux-calibrated simulated spectrum\")\n",
     "# The scaling for the source spectrum has been estimated by eye\n",
-    "plt.plot(src_wave, src_extract * 1500, label=\"input spectrum\")\n",
-    "plt.xlabel(r\"Wavelength [$\\mu$m]\")\n",
+    "# plt.plot(src_wave, src_extract * 1500, label=\"input spectrum\")\n",
+    "plt.plot(src_wave, src_extract * .42, label=\"input spectrum\")\n",
+    "plt.xlabel(f\"Wavelength [{src_wave.unit.to_string('latex')}]\")\n",
     "plt.ylabel(\"Relative flux\")\n",
     "plt.legend()\n",
     "plt.xlim(3.1, 4.0);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -871,7 +885,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.2"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Astropy units were used in this notebook in some parts, but not in others, which led to some inconsistencies. During the flux calibration, the background subtraction was scaled with the exposure time of the standard star, which I believe should not be the case. This also leads to a more realistic scaling factor in the final spectrum comparison (unless I'm missing something, scaling the source *down* to the result makes more sense, as the flux should decrease as it passes through the optical train).

Also made some plots look a little nicer and simplified some of the code.