### PR TITLE
Supply cube as hdul and not just file name

### DIFF
--- a/METIS/docs/example_notebooks/LSS_AGN-01_preparation.ipynb
+++ b/METIS/docs/example_notebooks/LSS_AGN-01_preparation.ipynb
@@ -236,7 +236,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = sim.Source(cube=\"AGN_sim_prepared.fits\")"
+    "with fits.open(\"AGN_sim_prepared.fits\") as cube_hdul:\n",
+    "    src = sim.Source(cube=cube_hdul)"
    ]
   },
   {
@@ -439,7 +440,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src50 = sim.Source(cube=\"AGN_sim_rotated_50.fits\")"
+    "with fits.open(\"AGN_sim_rotated_50.fits\") as cube_hdul:\n",
+    "    src50 = sim.Source(cube=cube_hdul)"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/LSS_AGN-02_simulation.ipynb
+++ b/METIS/docs/example_notebooks/LSS_AGN-02_simulation.ipynb
@@ -15,6 +15,7 @@
    "source": [
     "from matplotlib import pyplot as plt\n",
     "from matplotlib.colors import LogNorm\n",
+    "from astropy.io import fits\n",
     "%matplotlib inline"
    ]
   },
@@ -75,8 +76,10 @@
     "cube_01 = \"AGN_sim_prepared.fits\"\n",
     "cube_02 = \"AGN_sim_rotated_50.fits\"\n",
     "\n",
-    "src_01 = sim.Source(cube=cube_01)\n",
-    "src_02 = sim.Source(cube=cube_02)\n",
+    "with fits.open(cube_01) as cube_hdul:\n",
+    "    src_01 = sim.Source(cube=cube_hdul)\n",
+    "with fits.open(cube_02) as cube_hdul:\n",
+    "    src_02 = sim.Source(cube=cube_hdul)\n",
     "\n",
     "sky = sim.source.source_templates.empty_sky()"
    ]


### PR DESCRIPTION
Required for AstarVienna/ScopeSim#405 to not break the METIS notebooks.