### PR TITLE
Set PLOTS to False

### DIFF
--- a/METIS/tests/test_readout_exptime.py
+++ b/METIS/tests/test_readout_exptime.py
@@ -8,7 +8,7 @@ import scipy
 PKGS_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sim.rc.__config__["!SIM.file.local_packages_path"] = PKGS_DIR
 
-PLOTS = True
+PLOTS = False
 
 
 class TestReadoutExptime:


### PR DESCRIPTION
The plot from here popped up during collection time (?) when running pytest locally on the whole IRDB repo. This interrupted pytest until the figure window is closed manually.