### PR TITLE
Add instrument name in LFOA default.yaml

### DIFF
--- a/LFOA/default.yaml
+++ b/LFOA/default.yaml
@@ -12,6 +12,7 @@ yamls :
 - LFOA_SBIG.yaml
 
 properties :
+  instrument: LFOA
   airmass : 1.2
   declination : +30
   hour_angle : 0


### PR DESCRIPTION
One of the example notebooks in ScopeSim started producing `ValueError: !OBS.instrument was not found in rc.__currsys__` for the LFOA. This key is usually found in all other instrument packages. I vaguely remember fixing this, not sure if it was in a local branch on my other machine maybe...