### PR TITLE
Add package and mode status keywords and guide

### DIFF
--- a/HAWKI/default.yaml
+++ b/HAWKI/default.yaml
@@ -3,6 +3,7 @@ object : configuration
 alias : OBS
 name : HAWKI_default_configuration
 description : default parameters needed for a HAWKI simulation
+status: experimental
 date_modified: 2022-02-22
 changes:
   - 2022-02-22 (MV) formatting

--- a/LFOA/default.yaml
+++ b/LFOA/default.yaml
@@ -3,6 +3,7 @@ object : configuration
 alias : OBS
 name : LFOA_default_configuration
 description : default parameters needed for a LFOA simulation
+status: experimental
 
 packages :
 - LFOA

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -5,6 +5,7 @@ object: configuration
 alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
+status: development
 date_modified: 2022-03-14
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
@@ -64,6 +65,7 @@ mode_yamls:
     alias: OBS
     name: img_lm
     description: "METIS LM-band imaging"
+    status: development
     yamls:
       - METIS_IMG_LM.yaml
       - METIS_DET_IMG_LM.yaml
@@ -79,6 +81,7 @@ mode_yamls:
     alias: OBS
     name: img_n
     description: "METIS N-band imaging"
+    status: development
     yamls:
       - METIS_IMG_N.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
@@ -96,6 +99,7 @@ mode_yamls:
     alias: OBS
     name: lss_l
     description: "METIS L-band slit spectroscopy"
+    status: development
     yamls:
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
@@ -114,6 +118,7 @@ mode_yamls:
     alias: OBS
     name: lss_m
     description: "METIS M-band slit spectroscopy"
+    status: development
     yamls:
       - METIS_IMG_LM.yaml
       - METIS_LSS.yaml
@@ -132,6 +137,7 @@ mode_yamls:
     alias: OBS
     name: lss_n
     description: "METIS N-band slit spectroscopy"
+    status: development
     yamls:
       - METIS_IMG_N.yaml
       - METIS_LSS.yaml
@@ -150,6 +156,7 @@ mode_yamls:
     alias: OBS
     name: lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
+    status: experimental
     yamls:
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
@@ -165,6 +172,7 @@ mode_yamls:
     alias: OBS
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
+    status: experimental
     yamls:
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml

--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -5,6 +5,7 @@ object : configuration
 alias : OBS
 name : MICADO_default_configuration
 description : default parameters needed for a MICADO simulation
+status: development
 date_modified: 2023-07-13
 changes:
   - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits
@@ -61,6 +62,7 @@ mode_yamls :
   alias: OBS
   name : IMG_4mas
   description : "wide-field imager  : 4mas/pix"
+  status: development
   yamls :
   - MICADO_IMG_wide.yaml
   properties :
@@ -72,6 +74,7 @@ mode_yamls :
   alias: OBS
   name : IMG_1.5mas
   description : "high resolution imager  : 1.5mas/pix"
+  status: development
   yamls :
   - MICADO_IMG_zoom.yaml
   properties :
@@ -83,6 +86,7 @@ mode_yamls :
   alias: OBS
   name : IMG_HCI
   description : "High contrast imaging"
+  status: experimental
   yamls :
   - MICADO_IMG_HCI.yaml
 
@@ -90,6 +94,7 @@ mode_yamls :
   alias: OBS
   name : SPEC_15000x20
   description : "spectrograph : slit size 15000x20mas"
+  status: development
   yamls :
   - MICADO_SPEC.yaml
   properties :
@@ -103,6 +108,7 @@ mode_yamls :
   alias: OBS
   name : SPEC_3000x48
   description : "spectrograph : slit size 3000x48mas"
+  status: development
   yamls :
   - MICADO_SPEC.yaml
   properties :
@@ -116,6 +122,7 @@ mode_yamls :
   alias : OBS
   name : SPEC_3000x16
   description : "spectrograph : slit size 3000x16mas"
+  status: development
   yamls :
   - MICADO_SPEC.yaml
   properties :
@@ -129,6 +136,7 @@ mode_yamls :
   alias: OBS
   name : SPEC_15000x50
   description : "spectrograph : slit size 15000x50mas"
+  status: deprecated
   deprecate : "Deprecated instrument mode. For spectroscopy use
   - SPEC_3000x16
   - SPEC_3000x48
@@ -146,6 +154,7 @@ mode_yamls :
   alias: OBS
   name : SPEC_3000x50
   description : "spectrograph : slit size 3000x50mas"
+  status: deprecated
   deprecate : "Deprecated instrument mode. For spectroscopy use
   - SPEC_3000x16
   - SPEC_3000x48
@@ -163,6 +172,7 @@ mode_yamls :
   alias: OBS
   name : SPEC_3000x20
   description : "spectrograph : slit size 3000x20mas"
+  status: deprecated
   deprecate : "Deprecated instrument mode. For spectroscopy use
   - SPEC_3000x16
   - SPEC_3000x48

--- a/MICADO_Sci/default.yaml
+++ b/MICADO_Sci/default.yaml
@@ -9,6 +9,7 @@ object : configuration
 alias : OBS
 name : MICADO_sci_default_configuration
 description : default parameters needed for a MICADO-Sci simulation
+status : deprecated
 
 packages :
 - Armazones

--- a/OSIRIS/default.yaml
+++ b/OSIRIS/default.yaml
@@ -4,6 +4,7 @@ object : configuration
 alias : OBS
 name : OSIRIS_default_configuration
 description : default parameters needed for a OSIRIS simulation
+status: experimental
 date_created: 2022-03-02
 date_modified: 2022-03-02
 changes:

--- a/ViennaLT/default.yaml
+++ b/ViennaLT/default.yaml
@@ -4,6 +4,7 @@ object : configuration
 alias : OBS
 name : ViLT_default_configuration
 description : Vienna Little Telescope configuration
+status: experimental
 
 packages :
   - LFOA

--- a/WFC3/default.yaml
+++ b/WFC3/default.yaml
@@ -7,6 +7,7 @@ object : configuration
 alias : OBS
 name : HST_WFC3_default_config
 description : defatult configuration for HST WFC3 UVIS and NIR imaging
+status: experimental
 
 packages:
 - HST

--- a/docs/source/pkg_status.md
+++ b/docs/source/pkg_status.md
@@ -1,0 +1,19 @@
+# Definition of status keyword
+
+This can be added optionally to both the top-level of an instrument's `default.yaml` or to a mode section therein. By convention, it usually goes after the "description" key.
+
+## Permitted values and their meaning:
+
+- concept: The package or mode is not yet implemented and exists merely as a placeholder or to collect resource needed to actually implement it. Selecting this mode will result in a `NotImplementedError`.
+- experimental: Initial implementation of the package or mode is functional, but may still contain placeholders. Simulation results might not be representative of physical instrument.
+- development: Mostly stable working prototype, using best-guess values for effect definitions and data. Simulation results should be relatively close to physical instrument.
+- production: The package or mode is fully functional and stable and not expected to change substantially in the future. Simulation results are validated with reference documents.
+- deprecated: No longer supported, selecting this mode or package will result in a `DeprecationWarning`.
+
+The following values are currently under consideration to be added, but their role is not yet defined:
+
+- engineering
+
+## Combining package and mode statuses
+
+Basically, a package should only be marked as being in "production" status if all modes also have this status (except deprecated modes). A package in "development" status can contain modes of all statuses. In a "deprecated" package, all modes are implicitly considered deprecated. A package still in "concept" status should only contain modes of the same status. Once one mode is at least "experimental" (and thus functional), the whole package should be marked with the same status (otherwise it cannot be used), but other modes may very well still be in "concept" stage.

--- a/test_package/default.yaml
+++ b/test_package/default.yaml
@@ -2,6 +2,7 @@
 object : observation
 alias : OBS
 name : test_instrument
+status: production
 
 packages :
 - test_package


### PR DESCRIPTION
Corresponding ScopeSim PR coming soon.

This allows a better overview (for both developers and users) about the status of our packages and their individual modes.

This keyword is completely optional, omitting it does not result in any error.

The values intended to be used with this key and their meaning is summarized in the `pkg_status.md` guide, which becomes part of the documentation. Feedback or additions to that list are of course welcome 🙂 

To those with more "bigger picture" insight into the status of various packages and modes than myself: Please take a quick look at the statuses I used and simply request a change on this PR if you think a different one fits better for the current stage of the package or mode in question!

It is intended (at some point when there aren't as many other things to do - who am I kidding...) to incorporate the statuses in the respective package READMEs, probably as badges, together with the existing badge report thing...