### PR TITLE
adapt notebooks to PR scopesim_templates 124

### DIFF
--- a/METIS/docs/example_notebooks/demos/demo_grating_efficiency.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_grating_efficiency.ipynb
@@ -94,8 +94,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = flatlamp()\n",
-    "src.fields[0].spectra[0] = spec  # NB: do not try to set src.spectra[0] directly, this has no effect"
+    "src = flatlamp(spectrum=spec)"
    ]
   },
   {

--- a/METIS/docs/example_notebooks/demos/demo_rectify_traces.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_rectify_traces.ipynb
@@ -110,8 +110,7 @@
     "\n",
     "spec = SourceSpectrum(Empirical1D, points=wave*u.um, lookup_table=flux)\n",
     "\n",
-    "src_linelamp = flatlamp()\n",
-    "src_linelamp.fields[0].spectra[0] = spec     # NB: Do not try to set src_linelamp.spectra[0], this has no effect. "
+    "src_linelamp = flatlamp(spectrum=spec)"
    ]
   },
   {


### PR DESCRIPTION
Interface to `flatlamp()` changed in https://github.com/AstarVienna/ScopeSim_Templates/pull/124. If the removal of the wrapper in that PR is rejected, the notebooks should call `micado._flatlamp()` rather than `micado.flatlamp()`. 