### PR TITLE
Override !TEL.temperature in WCU mode

### DIFF
--- a/METIS/METIS_WCU.yaml
+++ b/METIS/METIS_WCU.yaml
@@ -44,3 +44,4 @@ alias: TEL
 properties:
   #area: 975.23478998
   area: 1354.593    #### TEST, needed to agree with RvB's calculation
+  temperature: "!WCU.temperature"  # Overrides !ATMO.temperature


### PR DESCRIPTION
This eliminates the need to load the ELT and Armazones packages when using METIS in one of the WCU modes. I also tested switching back and forth between e.g. "img_lm" and "wcu_img_lm" modes and !TEL.temperature does indeed switch as it should.

Fixes #218.