### PR TITLE
Run badge report tests separately

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,10 +23,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.10', '3.11', '3.12']
-        include:
-          - os: ubuntu-latest
-            python-version: '3.12'
-            upload-badges: True
 
     steps:
       - uses: actions/checkout@v4
@@ -42,8 +38,21 @@ jobs:
           pip install git+https://github.com/AstarVienna/ScopeSim_Templates.git
       - name: Run Pytest
         run: pytest
+
+  badge_report:
+    name: Generate Badge Report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install dependencies
+        run: pip install -r requirements.github_actions.txt
+      - name: Run Pytest for badges
+        run: pytest -m "badges"
       - name: Store badge report files
-        if: ${{ matrix.upload-badges }}
         uses: actions/upload-artifact@v4
         with:
           name: badge-report

--- a/HAWKI/test_hawki/test_full_package_hawki.py
+++ b/HAWKI/test_hawki/test_full_package_hawki.py
@@ -13,7 +13,6 @@ import pytest
 from pytest import approx
 import os
 import os.path as pth
-import shutil
 
 import numpy as np
 from astropy import units as u
@@ -62,6 +61,7 @@ class TestLoadUserCommands:
         assert len(stdout.out) == 0
 
 
+@pytest.mark.slow
 class TestMakeOpticalTrain:
     def test_works_seamlessly_for_hawki_package(self, capsys):
         cmd = scopesim.UserCommands(use_instrument="HAWKI")

--- a/irdb/tests/test_package_contents.py
+++ b/irdb/tests/test_package_contents.py
@@ -21,6 +21,9 @@ logging.shutdown()
 reload(logging)
 
 
+# Note: This module doesn't need to run always, so mark it.
+pytestmark = pytest.mark.badges
+
 # TODO: some tests should be skipped if something else has failed.
 # howto: https://stackoverflow.com/questions/75377691/skip-test-case-if-above-test-case-failed-pytest
 # and: https://pytest-dependency.readthedocs.io/en/stable/advanced.html

--- a/irdb/tests/test_package_contents.py
+++ b/irdb/tests/test_package_contents.py
@@ -38,7 +38,6 @@ def fixture_badges():
 
 
 @pytest.mark.parametrize("package", list(get_packages()))
-@pytest.mark.usefixtures("badges")
 class TestFileStructureOfPackages:
     def test_default_yaml_contains_packages_list(self, package, badges):
         pkg_name, pkg_path = package
@@ -154,7 +153,6 @@ class TestFileStructureOfPackages:
 
 
 @pytest.mark.parametrize("package", list(get_packages()))
-@pytest.mark.usefixtures("pkg_dir", "badges")
 class TestPackageDatFiles:
     @pytest.mark.xfail(
         reason=("Due to bad globbing, files in subfolders were not checked "

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,8 @@
 [pytest]
 # Prevent recursion into MICADO/docs/example_notebooks/inst_pkgs
-addopts = --ignore-glob="*/inst_pkgs/*"  -p no:randomly
+addopts = --ignore-glob="*/inst_pkgs/*"  -p no:randomly  -m "not badges"
 # Badge report needs order (at least for now, should be solved by using astar-utils NestedMapping)
 markers =
     webtest: mark a test as using network resources.
     slow: mark test as slow.
+    badges: tests for the badge report


### PR DESCRIPTION
No need to run those in the whole matrix, also solves the problem of multiple artifact uploads without having to use extra flags for certain matrix combination, which was the previous stopgap solution.