### PR TITLE
Use ExposureOutput in METIS

### DIFF
--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -72,6 +72,12 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 32
 
+  - name: exposure_output
+    description: Return average or sum over NDIT subexposures
+    class: ExposureOutput
+    kwargs:
+      mode: average
+
   - name: quantization
     description: Turn photon count into integers
     class: Quantization

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -91,6 +91,12 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 32
 
+  - name: exposure_output
+    description: Return average or sum over NDIT subexposures
+    class: ExposureOutput
+    kwargs:
+      mode: average
+
   - name: quantization
     description: Turn photon count into integers
     class: Quantization

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -98,6 +98,13 @@ effects:
     kwargs:
       mode: average
 
+  - name: ad_conversion
+    description: Apply gain and convert electron count into integers
+    class: ADConversion
+    kwargs:
+      dtype: uint16
+      gain: "!DET.gain"
+
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
@@ -106,10 +113,3 @@ effects:
       chop_offsets: "!OBS.chop_offsets"
       nod_offsets: "!OBS.nod_offsets"
       pixel_scale: "!INST.pixel_scale"
-
-  - name: ad_conversion
-    description: Apply gain and convert electron count into integers
-    class: ADConversion
-    kwargs:
-      dtype: uint16
-      gain: "!DET.gain"

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -91,6 +91,18 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 64
 
+  - name: exposure_output
+    description: Return average or sum over NDIT subexposures
+    class: ExposureOutput
+    kwargs:
+      mode: average
+
+  - name: quantization
+    description: Turn photon count into integers
+    class: Quantization
+    kwargs:
+      dtype: uint16
+
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
@@ -99,9 +111,3 @@ effects:
       chop_offsets: "!OBS.chop_offsets"
       nod_offsets: "!OBS.nod_offsets"
       pixel_scale: "!INST.pixel_scale"
-
-  - name: quantization
-    description: Turn photon count into integers
-    class: Quantization
-    kwargs:
-      dtype: uint16

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -98,12 +98,6 @@ effects:
     kwargs:
       mode: average
 
-  - name: quantization
-    description: Turn photon count into integers
-    class: Quantization
-    kwargs:
-      dtype: uint16
-
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -106,12 +106,6 @@ effects:
     kwargs:
       mode: average
 
-  - name: quantization
-    description: Turn photon count into integers
-    class: Quantization
-    kwargs:
-      dtype: uint16
-
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -94,6 +94,18 @@ effects:
       noise_std: "!DET.readout_noise"
       n_channels: 8
 
+  - name: exposure_output
+    description: Return average or sum over NDIT subexposures
+    class: ExposureOutput
+    kwargs:
+      mode: average
+
+  - name: quantization
+    description: Turn photon count into integers
+    class: Quantization
+    kwargs:
+      dtype: uint16
+
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
@@ -102,9 +114,3 @@ effects:
       chop_offsets: "!OBS.chop_offsets"
       nod_offsets: "!OBS.nod_offsets"
       pixel_scale: "!INST.pixel_scale"
-
-  - name: quantization
-    description: Turn photon count into integers
-    class: Quantization
-    kwargs:
-      dtype: uint16

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -106,6 +106,13 @@ effects:
     kwargs:
       mode: average
 
+  - name: ad_conversion
+    description: Apply gain and convert electron count into integers
+    class: ADConversion
+    kwargs:
+      dtype: uint16
+      gain: "!DET.gain"
+
   - name: chop_nod
     descriptions: chopping and nodding
     class: ChopNodCombiner
@@ -114,13 +121,6 @@ effects:
       chop_offsets: "!OBS.chop_offsets"
       nod_offsets: "!OBS.nod_offsets"
       pixel_scale: "!INST.pixel_scale"
-
-  - name: ad_conversion
-    description: Apply gain and convert electron count into integers
-    class: ADConversion
-    kwargs:
-      dtype: uint16
-      gain: "!DET.gain"
 
   - name: det_n_fits_keywords
     descriptions: FITS keywords specific to N detector

--- a/METIS/tests/test_readout_exptime.py
+++ b/METIS/tests/test_readout_exptime.py
@@ -1,3 +1,4 @@
+"""Test whether giving exptime in readout() is respected."""
 import copy
 import os
 from matplotlib import pyplot as plt
@@ -10,8 +11,7 @@ sim.rc.__config__["!SIM.file.local_packages_path"] = PKGS_DIR
 
 PLOTS = False
 
-
-class TestReadoutExptime:
+def test_readout_exptime():
     """Test whether giving exptime in readout() is respected.
 
     The implementation of Quantization and Autoexposure has lead
@@ -33,6 +33,7 @@ class TestReadoutExptime:
 
     # The first readout might ignore the exptime.
     metis_l = sim.OpticalTrain(cmd_l)
+    metis_l["exposure_output"].set_mode("sum")
     metis_l.observe(star, update=True)
     result_first = metis_l.readout(exptime=100.)[0]
     # We need to copy the first readeout, because
@@ -41,6 +42,7 @@ class TestReadoutExptime:
 
     # The second readout might not properly have the detector reset.
     metis_l = sim.OpticalTrain(cmd_l)
+    metis_l["exposure_output"].set_mode("sum")
     metis_l.observe(star, update=True)
     result_temp = metis_l.readout(exptime=100.)[0]
     result_temp_copy = copy.deepcopy(result_temp)


### PR DESCRIPTION
Use `ExposureOutput` in img_lm (to be expanded to other modes), see https://github.com/AstarVienna/ScopeSim/pull/603