### PR TITLE
Move TEL header keywords in METIS to ELT

### DIFF
--- a/ELT/ELT.yaml
+++ b/ELT/ELT.yaml
@@ -21,6 +21,13 @@ effects :
     kwargs :
       filename : LIST_ELT_combined.tbl
 
+  - name : telescope_fits_keywords
+    description : FITS keywords specific to the telescope
+    class : ExtraFitsKeywords
+    include : True
+    kwargs :
+      filename: FITS_telescope_keywords.yaml
+
 #  - name : scope_vibration
 #    description : residual vibration of telescope
 #    class : Vibration

--- a/ELT/FITS_telescope_keywords.yaml
+++ b/ELT/FITS_telescope_keywords.yaml
@@ -1,0 +1,11 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      WISE:
+        TEL:
+          NAME: "ELT"
+          TELESCOP: "ELT"
+          TER:
+            FILENAME: "!TEL.ter_curve.filename"
+          REF:
+            FILENAME: "#telescope_reflection.filename"

--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -211,24 +211,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "fc75f237-c61c-4659-b0db-be6a2c661bcc",
-   "metadata": {},
-   "source": [
-    "To make `readout` work, we currently have to turn off the effect that adds keywords to the resulting fits file. Including it would cause failure as it expects keywords related to the telescope, which are not available in WCU mode."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "de47de6a-6947-4c9e-ba06-494f7b6c2aa6",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "metis['common_fits_keywords'].include = False"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b2a3c4c9-a80d-4b90-b996-1a9297a5889a",

--- a/METIS/headers/FITS_common_keywords.yaml
+++ b/METIS/headers/FITS_common_keywords.yaml
@@ -138,13 +138,7 @@
           # TODO: Include a ReferencePixelBorder effect?
           #REF:
           #  ALL: "#border_reference_pixels.all"
-        TEL:
-          NAME: "ELT"
-          TELESCOP: "ELT"
-          TER:
-            FILENAME: "!TEL.ter_curve.filename"
-          REF:
-            FILENAME: "#telescope_reflection.filename"
+
         OCS:
           PXSCALE: "!INST.pixel_scale"
         OBS:


### PR DESCRIPTION
Together with @JenniferKarr and @hugobuddel we extracted the offending references in the METIS common FITS keywords file to telescope effects. These were causing METIS simulations to fail when generating WCU mode observations, because there is (quite obviously) no telescope involved in the process. 

The Gist of this PR is that TEL keywords are now contained in the ELT IRDB package.