### PR TITLE
Oc/subsystem fits keywords

### DIFF
--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -57,11 +57,18 @@ effects:
       minimum_throughput: !!float 0.
 
   - name : common_fits_keywords
-    decription : FITS keywords common to all modes
+    description : FITS keywords common to all modes
     class : ExtraFitsKeywords
     include : True
     kwargs :
       filename: headers/FITS_common_keywords.yaml
+
+  - name: cfo_fits_keywords
+    description: FITS keywords to CFO elements
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_cfo_keywords.yaml
 
 #  - name : metis_adc_residuals
 #    class : AtmosphericDispersionCorrection

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -77,3 +77,10 @@ effects:
     class: Quantization
     kwargs:
       dtype: uint16
+
+  - name: det_ifu_fits_keywords
+    descriptions: FITS keywords specific to IFU detectors
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_det_ifu_keywords.yaml

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -96,3 +96,10 @@ effects:
     class: Quantization
     kwargs:
       dtype: uint16
+
+  - name: det_lm_fits_keywords
+    descriptions: FITS keywords specific to LM detector
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_det_lm_keywords.yaml

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -108,3 +108,10 @@ effects:
     class: Quantization
     kwargs:
       dtype: uint16
+
+  - name: det_n_fits_keywords
+    descriptions: FITS keywords specific to N detector
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_det_n_keywords.yaml

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -12,6 +12,7 @@ changes:
   - 2022-01-12 (OC) change default bkg_width to -1
   - 2022-02-17 (OC) increase spectral_bin_width for imaging
   - 2022-02-21 (OC) renamed effects
+  - 2025-04-16 (OC) add ExtraFitsKeywords
 
 properties:
   pixel_scale: 0.00547         # arcsec / pixel, METIS_1097
@@ -80,6 +81,13 @@ effects:
       filename: "!OBS.psf_file"
       wave_key: "WAVELENG"
       bkg_width: -1
+
+  - name: img_lm_fits_keywords
+    descriptions: FITS keywords specific to IMG-LM
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_img_lm_keywords.yaml
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -75,6 +75,14 @@ effects:
       wave_key: "WAVELENG"
       bkg_width: -1
 
+  - name: img_n_fits_keywords
+    descriptions: FITS keywords specific to IMG-N
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_img_n_keywords.yaml
+
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/METIS_LMS.yaml
+++ b/METIS/METIS_LMS.yaml
@@ -56,7 +56,12 @@ effects:
       col_number_start: 1
       slice_samples: 5    # number of samples along slice width
 
-
+  - name: lms_fits_keywords
+    description: FITS keywords specific to LMS elements
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_lms_keywords.yaml
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -34,6 +34,13 @@ effects:
       s_colname: "xi"
       col_number_start: 1
 
+  - name: lss_fits_keywords
+    descriptions: FITS keywords specific to LSS
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_lss_keywords.yaml
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -123,6 +123,8 @@ mode_yamls:
       efficiency_file: TER_grating_L.fits
       slit: C-38_1
       adc: const_90
+      grism_opti9: GRISM_L
+      grism_opti12: open
       filter_name: L_spec
       nd_filter_name: open
       detector_readout_mode: slow
@@ -146,6 +148,8 @@ mode_yamls:
       efficiency_file: TER_grating_M.fits
       slit: C-38_1
       adc: const_90
+      grism_opti9: GRISM_M
+      grism_opti12: open
       filter_name: M_spec
       nd_filter_name: open
       detector_readout_mode: slow
@@ -169,8 +173,12 @@ mode_yamls:
       efficiency_file: TER_grating_N.fits
       slit: D-57_1
       adc: false
+      grism_opti9: open
+      grism_opti12: GRISM_N
       filter_name: N_spec
       nd_filter_name: open
+      chop_offsets: [3, 0]  # perpendicular chopping and nodding
+      nod_offsets: [0, 3]
       detector_readout_mode: low_capacity
 
   - object: observation
@@ -265,6 +273,8 @@ mode_yamls:
       efficiency_file: TER_grating_L.fits
       slit: C-38_1
       adc: const_90
+      grism_opti9: GRISM_L
+      grism_opti12: open
       filter_name: L_spec
       nd_filter_name: open
       detector_readout_mode: slow
@@ -286,6 +296,8 @@ mode_yamls:
       efficiency_file: TER_grating_M.fits
       slit: C-38_1
       adc: const_90
+      grism_opti9: GRISM_M
+      grism_opti12: open
       filter_name: M_spec
       nd_filter_name: open
       detector_readout_mode: slow
@@ -307,8 +319,12 @@ mode_yamls:
       efficiency_file: TER_grating_N.fits
       slit: D-57_1
       adc: false
+      grism_opti9: open
+      grism_opti12: GRISM_N
       filter_name: N_spec
       nd_filter_name: open
+      chop_offsets: [3, 0]  # perpendicular chopping and nodding
+      nod_offsets: [0, 3]
       detector_readout_mode: low_capacity
 
   - object: observation

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -67,7 +67,6 @@ mode_yamls:
     name: img_lm
     description: "METIS LM-band imaging"
     status: development
-    ins_mode: IMG_LM        # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -75,6 +74,7 @@ mode_yamls:
       - METIS_IMG_LM.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: IMG_LM        # use as FITS header keyword
       psf_file: PSF_SCAO_9mag_06seeing.fits
       filter_name: Lp
       nd_filter_name: open
@@ -87,7 +87,6 @@ mode_yamls:
     name: img_n
     description: "METIS N-band imaging"
     status: development
-    ins_mode: IMG_N         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -95,6 +94,7 @@ mode_yamls:
       - METIS_IMG_N.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
+      ins_mode: IMG_N         # use as FITS header keyword
       psf_file: PSF_SCAO_9mag_06seeing.fits
       filter_name: N2
       nd_filter_name: open
@@ -109,7 +109,6 @@ mode_yamls:
     name: lss_l
     description: "METIS L-band slit spectroscopy"
     status: development
-    ins_mode: LSS_L         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -118,6 +117,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: LSS_L         # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits
       trace_file: TRACE_LSS_L.fits
       efficiency_file: TER_grating_L.fits
@@ -132,7 +132,6 @@ mode_yamls:
     name: lss_m
     description: "METIS M-band slit spectroscopy"
     status: development
-    ins_mode: IMG_M         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -141,6 +140,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: IMG_M         # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits
       trace_file: TRACE_LSS_M.fits
       efficiency_file: TER_grating_M.fits
@@ -155,7 +155,6 @@ mode_yamls:
     name: lss_n
     description: "METIS N-band slit spectroscopy"
     status: development
-    ins_mode: IMG_N         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -164,6 +163,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
+      ins_mode: IMG_N         # use as FITS header keyword
       psf_file: PSF_N_9mag_06seeing.fits
       trace_file: TRACE_LSS_N.fits
       efficiency_file: TER_grating_N.fits
@@ -178,7 +178,6 @@ mode_yamls:
     name: lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
     status: experimental
-    ins_mode: LMS          # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -186,6 +185,7 @@ mode_yamls:
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
     properties:
+      ins_mode: LMS          # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits
       slit: false
       adc: false
@@ -198,7 +198,6 @@ mode_yamls:
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
     status: experimental
-    ins_mode: LMS           # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -206,6 +205,7 @@ mode_yamls:
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml
     properties:
+      ins_mode: LMS           # use as FITS header keyword
       slit: false
       adc: false
       detector_readout_mode: slow
@@ -232,13 +232,13 @@ mode_yamls:
     alias: OBS
     name: wcu_img_n
     description: "METIS N-band imaging"
-    ins_mode: IMG_N          # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
       - METIS_IMG_N.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
+      ins_mode: IMG_N          # use as FITS header keyword
       psf_file: PSF_SCAO_9mag_06seeing.fits    # REPLACE!
       filter_name: N2
       nd_filter_name: open
@@ -252,7 +252,6 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_l
     description: "METIS L-band slit spectroscopy"
-    ins_mode: LSS_L        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -260,6 +259,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: LSS_L        # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_L.fits
       efficiency_file: TER_grating_L.fits
@@ -273,7 +273,6 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_m
     description: "METIS M-band slit spectroscopy"
-    ins_mode: LSS_M        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -281,6 +280,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: LSS_M        # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_M.fits
       efficiency_file: TER_grating_M.fits
@@ -294,7 +294,6 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_n
     description: "METIS N-band slit spectroscopy"
-    ins_mode: LSS_N        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -302,6 +301,7 @@ mode_yamls:
       - METIS_LSS.yaml
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
+      ins_mode: LSS_N        # use as FITS header keyword
       psf_file: PSF_N_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_N.fits
       efficiency_file: TER_grating_N.fits
@@ -315,13 +315,13 @@ mode_yamls:
     alias: OBS
     name: wcu_lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
-    ins_mode: LMS          # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
       - METIS_LMS.yaml
       - METIS_DET_IFU.yaml
     properties:
+      ins_mode: LMS          # use as FITS header keyword
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       slit: false
       adc: false

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -67,6 +67,7 @@ mode_yamls:
     name: img_lm
     description: "METIS LM-band imaging"
     status: development
+    ins_mode: IMG_LM        # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -86,6 +87,7 @@ mode_yamls:
     name: img_n
     description: "METIS N-band imaging"
     status: development
+    ins_mode: IMG_N         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -107,6 +109,7 @@ mode_yamls:
     name: lss_l
     description: "METIS L-band slit spectroscopy"
     status: development
+    ins_mode: LSS_L         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -129,6 +132,7 @@ mode_yamls:
     name: lss_m
     description: "METIS M-band slit spectroscopy"
     status: development
+    ins_mode: IMG_M         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -151,6 +155,7 @@ mode_yamls:
     name: lss_n
     description: "METIS N-band slit spectroscopy"
     status: development
+    ins_mode: IMG_N         # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -173,6 +178,7 @@ mode_yamls:
     name: lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
     status: experimental
+    ins_mode: LMS          # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -192,6 +198,7 @@ mode_yamls:
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
     status: experimental
+    ins_mode: LMS           # use as FITS header keyword
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -213,6 +220,7 @@ mode_yamls:
       - METIS_IMG_LM.yaml
       - METIS_DET_IMG_LM.yaml
     properties:
+      ins_mode: IMG_LM        # use as FITS header keyword
       psf_file: PSF_SCAO_9mag_06seeing.fits  # REPLACE!
       filter_name: Lp
       nd_filter_name: open
@@ -224,6 +232,7 @@ mode_yamls:
     alias: OBS
     name: wcu_img_n
     description: "METIS N-band imaging"
+    ins_mode: IMG_N          # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -243,6 +252,7 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_l
     description: "METIS L-band slit spectroscopy"
+    ins_mode: LSS_L        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -263,6 +273,7 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_m
     description: "METIS M-band slit spectroscopy"
+    ins_mode: LSS_M        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -283,6 +294,7 @@ mode_yamls:
     alias: OBS
     name: wcu_lss_n
     description: "METIS N-band slit spectroscopy"
+    ins_mode: LSS_N        # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -303,6 +315,7 @@ mode_yamls:
     alias: OBS
     name: wcu_lms
     description: "METIS LM-band integral-field spectroscopy, nominal mode"
+    ins_mode: LMS          # use as FITS header keyword
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -326,6 +339,7 @@ mode_yamls:
       - METIS_LMS_EXT.yaml
       - METIS_DET_IFU.yaml
     properties:
+      ins_mode: LMS          # use as FITS header keyword
       slit: false
       adc: false
       detector_readout_mode: slow

--- a/METIS/headers/FITS_cfo_keywords.yaml
+++ b/METIS/headers/FITS_cfo_keywords.yaml
@@ -1,0 +1,18 @@
+- ext_type: PrimaryHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        INS:
+          OPTI1:                # CFO PP1 mask wheel
+            # TODO: There are no names yet. We use the
+            #       transmission, which is returned as an
+            #       inconvenient list.
+            DESC: "CFO PP1 mask wheel"
+            NAME: "#cold_stop.transmission!"
+          OPTI2:                # CFO PP1 ADC wheel
+            DESC: "ADC wheel"
+            NAME: "#adc_wheel.current_adc!"
+          OPTI3:                # CFO FP2 mask/slit wheel
+            DESC: "Slit wheel"
+            NAME: "#slit_wheel.current_slit!"

--- a/METIS/headers/FITS_common_keywords.yaml
+++ b/METIS/headers/FITS_common_keywords.yaml
@@ -87,7 +87,7 @@
           #
           # Many more are defined in E-LIS-KUL-MET-1002. Not all possible INS
           # keywords are applicable to all observation modes.
-          #
+          MODE:   "!OBS.ins_mode"    # Instrument mode
           # TODO: Add the OPTI keywords, but probably in separate yaml files
           #       for each mode.
           #OPTI6:

--- a/METIS/headers/FITS_det_ifu_keywords.yaml
+++ b/METIS/headers/FITS_det_ifu_keywords.yaml
@@ -1,0 +1,24 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        DET3:
+          DIT:        "!OBS.dit"
+          NDIT:       "!OBS.ndit"
+          CUBE:
+            MODE:     "F"
+
+- ext_type: ImageHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        DET3:
+          CHIP:
+            ID:       "!DET.detector"
+            #MODE:     "#detector_readout_parameters.mode_properties"
+            MINDIT:   "!DET.mindit"
+            FULLWELL: "!DET.full_well"
+            RON:      "!DET.readout_noise"
+            DARK:     "!DET.dark_current"
+            #GAIN:     "!DET.gain"

--- a/METIS/headers/FITS_det_lm_keywords.yaml
+++ b/METIS/headers/FITS_det_lm_keywords.yaml
@@ -1,0 +1,23 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        DET1:
+          DIT:        "!OBS.dit"
+          NDIT:       "!OBS.ndit"
+          CUBE:
+            MODE:    "F"
+
+- ext_type: ImageHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        DET1:
+          CHIP:
+            ID:       "!DET.detector"
+            #MODE:     "#detector_readout_parameters.mode_properties"
+            MINDIT:   "!DET.mindit"
+            FULLWELL: "!DET.full_well"
+            RON:      "!DET.readout_noise"
+            DARK:     "!DET.dark_current"
+            #GAIN:     "!DET.gain"

--- a/METIS/headers/FITS_det_lm_keywords.yaml
+++ b/METIS/headers/FITS_det_lm_keywords.yaml
@@ -15,7 +15,7 @@
         DET1:
           CHIP:
             ID:       "!DET.detector"
-            #MODE:     "#detector_readout_parameters.mode_properties"
+            MODE:     "!OBS.detector_readout_mode!"
             MINDIT:   "!DET.mindit"
             FULLWELL: "!DET.full_well"
             RON:      "!DET.readout_noise"

--- a/METIS/headers/FITS_det_n_keywords.yaml
+++ b/METIS/headers/FITS_det_n_keywords.yaml
@@ -7,6 +7,11 @@
           NDIT:       "!OBS.ndit"
           CUBE:
             MODE:    "F"
+        SEQ:
+          CHOPNOD:
+            ST:      "#chop_nod.include"
+            OFFSCHOP: ["!OBS.chop_offsets", "[arcsec]"]
+            OFFSNOD:  ["!OBS.nod_offsets", "[arcsec"]
 
 - ext_type: ImageHDU
   keywords:
@@ -16,7 +21,7 @@
         DET2:
           CHIP:
             ID:       "!DET.detector"
-            #MODE:     "#detector_readout_parameters.mode_properties"
+            MODE:     "!OBS.detector_readout_mode!"
             MINDIT:   "!DET.mindit"
             FULLWELL: "!DET.full_well"
             RON:      "!DET.readout_noise"

--- a/METIS/headers/FITS_det_n_keywords.yaml
+++ b/METIS/headers/FITS_det_n_keywords.yaml
@@ -1,0 +1,24 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        DET2:
+          DIT:        "!OBS.dit"
+          NDIT:       "!OBS.ndit"
+          CUBE:
+            MODE:    "F"
+
+- ext_type: ImageHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        DET2:
+          CHIP:
+            ID:       "!DET.detector"
+            #MODE:     "#detector_readout_parameters.mode_properties"
+            MINDIT:   "!DET.mindit"
+            FULLWELL: "!DET.full_well"
+            RON:      "!DET.readout_noise"
+            DARK:     "!DET.dark_current"
+            #GAIN

--- a/METIS/headers/FITS_img_lm_keywords.yaml
+++ b/METIS/headers/FITS_img_lm_keywords.yaml
@@ -1,0 +1,15 @@
+- ext_type: PrimaryHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        INS:
+          OPTI9:                # IMG-LM mask/grism wheel
+            ID: "IMG-LM mask/grism"
+            NAME: "open"
+          OPTI10:               # IMG-LM science filter wheel
+            ID: "IMG-LM science filter"
+            NAME: "#filter_wheel.current_filter"
+          OPTI11:               # IMG-LM neutral density filter wheel
+            ID: "IMG-LM neutral density filter"
+            NAME: "#nd_filter_wheel.current_filter"

--- a/METIS/headers/FITS_img_lm_keywords.yaml
+++ b/METIS/headers/FITS_img_lm_keywords.yaml
@@ -4,7 +4,9 @@
     HIERARCH:
       ESO:
         INS:
-          MODE: "IMG_LM"
+          OPTI4:                # LMS beamsplitter pickoff wheel
+            DESC: "LMS pickoff"
+            NAME: "OUT"         # could be IN for parallel observing
           OPTI9:                # IMG-LM mask/grism wheel
             DESC: "IMG-LM mask/grism"
             NAME: "open"

--- a/METIS/headers/FITS_img_lm_keywords.yaml
+++ b/METIS/headers/FITS_img_lm_keywords.yaml
@@ -9,7 +9,7 @@
             NAME: "open"
           OPTI10:               # IMG-LM science filter wheel
             ID: "IMG-LM science filter"
-            NAME: "#filter_wheel.current_filter"
+            NAME: "#filter_wheel.current_filter!"
           OPTI11:               # IMG-LM neutral density filter wheel
             ID: "IMG-LM neutral density filter"
-            NAME: "#nd_filter_wheel.current_filter"
+            NAME: "#nd_filter_wheel.current_filter!"

--- a/METIS/headers/FITS_img_lm_keywords.yaml
+++ b/METIS/headers/FITS_img_lm_keywords.yaml
@@ -4,12 +4,13 @@
     HIERARCH:
       ESO:
         INS:
+          MODE: "IMG_LM"
           OPTI9:                # IMG-LM mask/grism wheel
-            ID: "IMG-LM mask/grism"
+            DESC: "IMG-LM mask/grism"
             NAME: "open"
           OPTI10:               # IMG-LM science filter wheel
-            ID: "IMG-LM science filter"
+            DESC: "IMG-LM science filter"
             NAME: "#filter_wheel.current_filter!"
           OPTI11:               # IMG-LM neutral density filter wheel
-            ID: "IMG-LM neutral density filter"
+            DESC: "IMG-LM neutral density filter"
             NAME: "#nd_filter_wheel.current_filter!"

--- a/METIS/headers/FITS_img_n_keywords.yaml
+++ b/METIS/headers/FITS_img_n_keywords.yaml
@@ -4,17 +4,17 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "IMAGE,LM"
+          TECH:   "IMAGE,N"
         INS:
           OPTI4:                # LMS beamsplitter pickoff wheel
             DESC: "LMS pickoff"
             NAME: "OUT"         # could be IN for parallel observing
-          OPTI9:                # IMG-LM mask/grism wheel
-            DESC: "IMG-LM mask/grism"
+          OPTI12:                # IMG-N mask/grism wheel
+            DESC: "IMG-N mask/grism"
             NAME: "open"
-          OPTI10:               # IMG-LM science filter wheel
-            DESC: "IMG-LM science filter"
+          OPTI13:               # IMG-N science filter wheel
+            DESC: "IMG-N science filter"
             NAME: "#filter_wheel.current_filter!"
-          OPTI11:               # IMG-LM neutral density filter wheel
-            DESC: "IMG-LM neutral density filter"
+          OPTI14:               # IMG-N neutral-density filter wheel
+            DESC: "IMG-N neutral density filter"
             NAME: "#nd_filter_wheel.current_filter!"

--- a/METIS/headers/FITS_lms_keywords.yaml
+++ b/METIS/headers/FITS_lms_keywords.yaml
@@ -3,6 +3,8 @@
 
     HIERARCH:
       ESO:
+        DPR:
+          TECH:   "LMS"
         INS:
           LMS:                  # LMS mode (Nominal or Extended)
             MODE: "Nominal"

--- a/METIS/headers/FITS_lms_keywords.yaml
+++ b/METIS/headers/FITS_lms_keywords.yaml
@@ -1,0 +1,28 @@
+- ext_type: PrimaryHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        INS:
+          LMS:                  # LMS mode (Nominal or Extended)
+            MODE: "Nominal"
+          WLEN:                 # LMS central wavelength and range
+            CEN:   ["!OBS.wavelen", "Central wavelength [um]"]
+            START: "TBD"  # "#lms_spectral_traces.wave_min" ain't workin'
+            END:   "TBD"
+          GRAT:
+            ANGLE: "TBD"
+          OPTI4:                # LMS beamsplitter pickoff wheel
+            DESC: "LMS pickoff"
+            NAME: "IN"
+          OPTI5:                # LMS PP1 mask wheel
+            DESC: "LMS PP1 mask wheel"
+            NAME: "open"        # TODO: not defined in irdb
+          OPTI6:                # LMS spectral IFU mechanism
+            DESC: "LMS spectral IFU mechanism"
+            NAME: "OUT"
+          OPTI7:                # LMS pre-disperser
+            DESC: "LMS pre-disperser"
+            NAME: "TBD"
+          OPTI8:                # LMS main disperser
+            NAME: "TBD"         # identical to GRAT.ANGLE?

--- a/METIS/headers/FITS_lms_keywords.yaml
+++ b/METIS/headers/FITS_lms_keywords.yaml
@@ -4,7 +4,7 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "LMS"
+          TECH:   "IFU"
         INS:
           LMS:                  # LMS mode (Nominal or Extended)
             MODE: "Nominal"

--- a/METIS/headers/FITS_lss_keywords.yaml
+++ b/METIS/headers/FITS_lss_keywords.yaml
@@ -11,4 +11,7 @@
             NAME: "OUT"         # could be IN for parallel observing
           OPTI9:                # IMG-LM mask/grism wheel
             DESC: "IMG-LM mask/grism"
-            NAME: "!OBS.trace_file"   # This should be translated!
+            NAME: "!OBS.grism_opti9"
+          OPTI12:               # IMG-N mask/grism wheel
+            DESC: "IMG-N mask/grism"
+            NAME: "!OBS.grism_opti12"

--- a/METIS/headers/FITS_lss_keywords.yaml
+++ b/METIS/headers/FITS_lss_keywords.yaml
@@ -1,0 +1,14 @@
+- ext_type: PrimaryHDU
+  keywords:
+
+    HIERARCH:
+      ESO:
+        DPR:
+          TECH:   "LSS"         # TODO: How to add the filter name?
+        INS:
+          OPTI4:                # LMS beamsplitter pickoff wheel
+            DESC: "LMS pickoff"
+            NAME: "OUT"         # could be IN for parallel observing
+          OPTI9:                # IMG-LM mask/grism wheel
+            DESC: "IMG-LM mask/grism"
+            NAME: "!OBS.trace_file"   # This should be translated!

--- a/METIS/headers/FITS_wcu_keywords.yaml
+++ b/METIS/headers/FITS_wcu_keywords.yaml
@@ -16,8 +16,12 @@
           OPTI20:               # WCU FP2.1 mask wheel
             DESC: "WCU FP2.1 mask"
             NAME: "#wcu_source.current_fpmask"
-          WCU_LAMP:             # WCU lamp TODO: made up keyword
-            DESC: "WCU lamp"
-            NAME: "#wcu_source.current_lamp"
         SEQ:
           WCU_BB_TEMP: "#wcu_source.bb_temp"
+          WCU:
+            LASER1: "ON"
+            LASER2: "ON"              # TODO: need a wavelength
+            LASER3: "ON"
+            LAMP:                     # WCU lamp TODO: made up keyword
+              DESC: "WCU lamp"
+              NAME: "#wcu_source.current_lamp"


### PR DESCRIPTION
This PR adds `ExtraFitsKeywords` to the various METIS subsystems. The goal is to automatise setting keywords consistent with current knowledge of the observing templates and METIS FITS keyword definitions (these definitions have gaps so expect updates to the settings at a later stage of the project). 

- [x] `METIS.yaml`: `headers/FITS_cfo_keywords.yaml`
- [x] `METIS_IMG_LM.yaml`:   `headers/FITS_img_lm_keywords.yaml`
- [x] `METIS_IMG_N.yaml`: `headers/FITS_img_n_keywords.yaml`
- [x] `METIS_LMS.yaml`: `headers/FITS_lms_keywords.yaml`
- [x] `METIS_LSS.yaml`: `headers/FITS_lss_keywords.yaml`
- [x] `METIS_DET_IMG_LM.yaml`: `headers/FITS_det_img_lm_keywords.yaml`
- [x] `METIS_DET_IMG_N_Geosnap.yaml`: `headers/FITS_det_img_n_geosnap_keywords.yaml`
- [x] `METIS_DET_IFU.yaml`: `headers/FITS_det_ifu_keywords.yaml`

Spectral keywords cannot be written yet due to a scopesim issue (https://github.com/AstarVienna/ScopeSim/issues/644; conflicting redefinitions of `__getitem__` in `OpticsManager`, `Effect` and `SpectralTracelist`).