### PR TITLE
Minor cleanup in WCU notebook

### DIFF
--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -48,18 +48,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from astropy import units as u"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3c430849",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "%matplotlib inline"
+    "from astropy import units as u\n",
+    "from matplotlib import pyplot as plt"
    ]
   },
   {
@@ -72,7 +62,7 @@
     "import scopesim as sim\n",
     "\n",
     "# Edit this path if you have a custom install directory, otherwise comment it out. [For ReadTheDocs only]\n",
-    "sim.rc.__config__[\"!SIM.file.local_packages_path\"] = \"../../../\""
+    "sim.link_irdb(\"../../../\")"
    ]
   },
   {
@@ -186,8 +176,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(metis.image_planes[0].data, origin='lower')\n",
-    "plt.colorbar();"
+    "fig, ax = plt.subplots()\n",
+    "img = ax.imshow(metis.image_planes[0].data, origin=\"lower\")\n",
+    "fig.colorbar(img);"
    ]
   },
   {
@@ -227,8 +218,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(hdul[1].data, vmin=92000, vmax=92600)\n",
-    "plt.colorbar();\n",
+    "fig, ax = plt.subplots()\n",
+    "img = ax.imshow(hdul[1].data, vmin=92000, vmax=92600)\n",
+    "fig.colorbar(img)\n",
     "print(f\"Mean:               {hdul[1].data.mean():7.1f}\")\n",
     "print(f\"Standard deviation: {hdul[1].data.std(): 7.1f}\")"
    ]
@@ -258,9 +250,10 @@
     "    metis.observe()\n",
     "    signal[i] = metis.image_planes[0].data.mean()\n",
     "\n",
-    "plt.plot(temps, signal, 'o')\n",
-    "plt.xlabel(\"Black-body temperature [K]\")\n",
-    "plt.ylabel(\"Image-plane flux [ph/s/pixel]\");"
+    "_, ax = plt.subplots()\n",
+    "ax.plot(temps, signal, 'o')\n",
+    "ax.set_xlabel(\"Black-body temperature [K]\")\n",
+    "ax.set_ylabel(\"Image-plane flux [ph/s/pixel]\");"
    ]
   },
   {
@@ -288,9 +281,10 @@
     "    metis.observe()\n",
     "    signal[i] = metis.image_planes[0].data.mean()\n",
     "\n",
-    "plt.plot(bb_ap, signal, 'o')\n",
-    "plt.xlabel(\"Fraction of flux transmitted into IS\")\n",
-    "plt.ylabel(\"Image-plane flux [ph/s/pixel]\");"
+    "_, ax = plt.subplots()\n",
+    "ax.plot(bb_ap, signal, 'o')\n",
+    "ax.set_xlabel(\"Fraction of flux transmitted into IS\")\n",
+    "ax.set_ylabel(\"Image-plane flux [ph/s/pixel]\");"
    ]
   },
   {
@@ -326,7 +320,8 @@
     "wcu.set_fpmask(\"grid_lm\", angle=20, shift=(1, 0.5))\n",
     "print(wcu.fpmask)\n",
     "metis.observe()\n",
-    "plt.imshow(metis.image_planes[0].data, norm='log', origin='lower')"
+    "_, ax = plt.subplots()\n",
+    "ax.imshow(metis.image_planes[0].data, norm=\"log\", origin=\"lower\");"
    ]
   },
   {
@@ -418,9 +413,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axes = plt.subplots(1, 2, figsize=(10, 10))\n",
-    "axes[0].imshow(implane_bb - implane_off, origin='lower', norm='symlog')\n",
-    "axes[1].imshow(implane_laser - implane_off, origin='lower', norm='symlog');"
+    "fig, (ax0, ax1) = plt.subplots(1, 2, figsize=(10, 5))\n",
+    "ax0.imshow(implane_bb - implane_off, origin=\"lower\", norm=\"symlog\")\n",
+    "ax1.imshow(implane_laser - implane_off, origin=\"lower\", norm=\"symlog\");"
    ]
   },
   {


### PR DESCRIPTION
I never saw plots anymore (after some update to Jupyter months ago) unless I explicitly added `plt.show()` everywhere. Finally figured out that _removing_ the `%matplotlib inline` solves that. Now I don't know if this breaks it for anyone else?

Also added the new `sim.link_irdb()`, let's see if that also works on RTD.