### PR TITLE
Fix test class that should be a function

### DIFF
--- a/METIS/tests/test_readout_exptime.py
+++ b/METIS/tests/test_readout_exptime.py
@@ -11,7 +11,7 @@ sim.rc.__config__["!SIM.file.local_packages_path"] = PKGS_DIR
 PLOTS = False
 
 
-class TestReadoutExptime:
+def test_readout_exptime():
     """Test whether giving exptime in readout() is respected.
 
     The implementation of Quantization and Autoexposure has lead


### PR DESCRIPTION
A very similar thing occurred recently but I cannot find it right now: The code for this test was in the class body (as opposed to within a method), so it was executed during collection time and not a an actual test. Simple solution: just make it a function, it's just a single test case anyway.