### PR TITLE
Rename `SummedExposure` ➡️ `ExposureIntegration`

### DIFF
--- a/HAWKI/HAWKI_H2RG.yaml
+++ b/HAWKI/HAWKI_H2RG.yaml
@@ -39,9 +39,9 @@ effects :
     kwargs :
         filename : QE_detector_H2RG.dat
 
--   name: exposure_action
+-   name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
 -   name: dark_current
     description : HAWKI dark current

--- a/LFOA/LFOA_SBIG.yaml
+++ b/LFOA/LFOA_SBIG.yaml
@@ -41,9 +41,9 @@ effects :
     kwargs :
         filename : QE_SBIG.dat
 
--   name: exposure_action
+-   name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
 -   name: dark_current
     description : SBIG dark current

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -88,7 +88,7 @@ effects:
     description: Apply gain and convert electron count into integers
     class: ADConversion
     kwargs:
-      dtype: uint16
+      dtype: float32
       gain: "!DET.gain"
 
   - name: det_ifu_fits_keywords

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -51,9 +51,9 @@ effects:
     kwargs:
       fill_frac: "!OBS.auto_exposure.fill_frac"
 
-  - name: exposure_action
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
   - name: dark_current
     description: METIS LMS dark current

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -106,7 +106,7 @@ effects:
     description: Apply gain and convert electron counts into integers
     class: ADConversion
     kwargs:
-      dtype: uint16
+      dtype: float32
       gain: "!DET.gain"
 
   - name: det_lm_fits_keywords

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -68,9 +68,9 @@ effects:
       full_well: "!DET.full_well"
       mindit: "!DET.mindit"
 
-  - name: summed_exposure
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
   - name: dark_current
     description: METIS LM dark current

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -65,9 +65,9 @@ effects:
     kwargs:
       fill_frac: "!OBS.auto_exposure.fill_frac"
 
-  - name: summed_exposure
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
   - name: dark_current
     description: METIS Aquarius dark current

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -102,7 +102,7 @@ effects:
     description: Apply gain and convert electron count into integers
     class: ADConversion
     kwargs:
-      dtype: uint16
+      dtype: float32
       gain: "!DET.gain"
 
   - name: chop_nod

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -72,9 +72,9 @@ effects:
       full_well: "!DET.full_well"
       mindit: "!DET.mindit"
 
-  - name: summed_exposure
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
   - name: dark_current
     description: METIS GeoSnap dark current

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -110,7 +110,7 @@ effects:
     description: Apply gain and convert electron count into integers
     class: ADConversion
     kwargs:
-      dtype: uint16
+      dtype: float32
       gain: "!DET.gain"
 
   - name: chop_nod

--- a/METIS/docs/example_notebooks/demos/demo_auto_exposure.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_auto_exposure.ipynb
@@ -95,7 +95,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime=1)[0][1].data \n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "print(\"\\nResult\\n======\")\n",
@@ -118,7 +118,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime = 1000)[0][1].data \n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "print(\"\\nResult\\n======\")\n",
@@ -141,7 +141,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime = 1000, fill_frac=0.9)[0][1].data \n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "print(\"\\nResult\\n======\")\n",
@@ -191,7 +191,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime=1)[0][1].data \n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "print(\"\\nResult\\n======\")\n",
@@ -241,7 +241,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime=3600.)[0][1].data \n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "\n",
@@ -302,7 +302,7 @@
    "outputs": [],
    "source": [
     "outimg = metis.readout(exptime=1)[0][1].data\n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "full_well = metis.cmds[\"!DET.full_well\"]\n",
     "\n",
@@ -363,7 +363,7 @@
    "source": [
     "full_well = 1000 * metis.cmds[\"!DET.full_well\"]\n",
     "outimg = metis.readout(exptime=1, full_well=full_well)[0][1].data\n",
-    "outimg = outimg / metis.cmds[metis['summed_exposure'].meta['ndit']]\n",
+    "outimg = outimg / metis.cmds[metis['exposure_integration'].meta['ndit']]\n",
     "\n",
     "print(\"\\nResult\\n======\")\n",
     "print(\"Maximum value in readout (per DIT): {:9.1f}\".format(outimg.max()))\n",

--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -42,9 +42,9 @@ effects :
     kwargs :
         filename : QE_detector_H4RG.dat
 
--   name: exposure_action
+-   name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
 -   name: dark_current
     description : MICADO dark current
@@ -108,5 +108,3 @@ effects :
     include : True
     kwargs :
       filename: FITS_extra_keywords.yaml
-
-

--- a/MICADO_Sci/MICADO_Sci_detector.yaml
+++ b/MICADO_Sci/MICADO_Sci_detector.yaml
@@ -7,7 +7,7 @@
 # contains:
 # - DetectorWindow
 # - QuantumEfficiencyCurve
-# - SummedExposure
+# - ExposureIntegration
 # - DarkCurrent
 # - LinearityCurve
 # - ShotNoise
@@ -47,9 +47,9 @@ effects:
     kwargs :
         filename : QE_detector_H2RG.dat
 
--   name: exposure_action
+-   name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
 -   name: dark_current
     fits_alias: DAR

--- a/OSIRIS/OSIRIS_DET.yaml
+++ b/OSIRIS/OSIRIS_DET.yaml
@@ -34,9 +34,9 @@ effects :
       gain_unit : electron/adu
       image_plane_id : 0
 
-  - name: exposure_action
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
   - name: dark_current
     description : OSIRIS dark current

--- a/ViennaLT/ViLT_PL16803.yaml
+++ b/ViennaLT/ViLT_PL16803.yaml
@@ -22,9 +22,9 @@ effects :
     kwargs :
         filename : QE_SBIG.dat     # TODO: should be changed to PL16803
 
--   name: exposure_action
+-   name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
-    class: SummedExposure
+    class: ExposureIntegration
 
 -   name: dark_current
     description : PL16803 dark current

--- a/WFC3/WFC3_IR_DET.yaml
+++ b/WFC3/WFC3_IR_DET.yaml
@@ -32,9 +32,9 @@ effects:
       kwargs:
         filename: wfc3_ir_qe_003_syn.dat
 
-    - name: exposure_action
+    - name: exposure_integration
       description: Summing up sky signal for all DITs and NDITs
-      class: SummedExposure
+      class: ExposureIntegration
 
     - name: detector_border
       decription: blacks out the pixels at the edge of the detector


### PR DESCRIPTION
Implements #239. All instances of `SummedExposure` have been changed to `ExposureIntegration`. The effect name has been homogenised to `exposure_integration`.  