### PR TITLE
Remove all remaining `version.yaml` files

### DIFF
--- a/Armazones/version.yaml
+++ b/Armazones/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2023-07-11 10:03:42'
-version: '2023-07-11'

--- a/ELT/version.yaml
+++ b/ELT/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2023-07-11 10:03:42'
-version: '2023-07-11'

--- a/HAWKI/version.yaml
+++ b/HAWKI/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2023-06-14 15:16:08'
-version: '2023-06-14'

--- a/LFOA/version.yaml
+++ b/LFOA/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2022-04-12 13:06:04'
-version: '2022-04-12'

--- a/METIS/version.yaml
+++ b/METIS/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2024-05-14 21:03:42'
-version: '2024-05-14'

--- a/MICADO/version.yaml
+++ b/MICADO/version.yaml
@@ -1,3 +1,0 @@
-release: dev
-timestamp: '2023-07-14 12:18:40'
-version: 2023-07-14.dev

--- a/MORFEO/version.yaml
+++ b/MORFEO/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2023-07-11 10:11:35'
-version: '2023-07-11'

--- a/Paranal/version.yaml
+++ b/Paranal/version.yaml
@@ -1,3 +1,0 @@
-release: stable
-timestamp: '2022-04-09 15:30:09'
-version: '2022-04-09'

--- a/test_package/version.yaml
+++ b/test_package/version.yaml
@@ -1,3 +1,0 @@
-release: dev
-timestamp: '2023-07-20 00:50:17'
-version: 2023-07-20.dev


### PR DESCRIPTION
Those had been obsolete for more than one year, since we updated our release workflow. When a package is compliled to be uploaded to the server, a `version.yaml` file is created on the fly from the current timestamp and packaged in the zip file, so a package installed from the server has the version information corresponding to a tag.

But these newly created `version.yaml` files are not committed back into the repo (on purpose), so the old ones that were still there showed wildly outdated timestamps, which greatly confuses some users (see e.g. the post- merge comment in #241, although that shouldn't be _there_ but whatever) when installing from the repo.

I'm working on adding the funcitonality to `sim.bug_report()` to display a meaningful version information when a package was installed from source, but that will also be easier with those outdated `version.yaml` files gone.

IIRC we actually decided to remove them back when we updated the release workflow, but then forgot about it...