### PR TITLE
Add `ExposureOutput` and `ADConversion` to MICADO

### DIFF
--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -1,29 +1,30 @@
 ### H4RG DETECTOR
-object : detector
-alias : DET
-name : MICADO_DET
-description : A set of 9 H4RG detectors
+object: detector
+alias: DET
+name: MICADO_DET
+description: A set of 9 H4RG detectors
 
-properties :
-    image_plane_id : 0
-    temperature : -230
-    dit : "!OBS.dit"
-    ndit : "!OBS.ndit"
+properties:
+    image_plane_id: 0
+    temperature: -230
+    dit: "!OBS.dit"
+    ndit: "!OBS.ndit"
     width: 1024
     height: 1024
     x: 0
     y: 0
+    gain: 1  # should be taken from FPA layout??
 
-effects :
--   name: full_detector_array
-    description : THe full 3x3 MICADO detector array list
+effects:
+  - name: full_detector_array
+    description : The full 3x3 MICADO detector array list
     class: DetectorList
     include: False
     kwargs:
         filename : FPA_array_layout.dat
         active_detectors : "all"
 
--   name: detector_window
+  - name: detector_window
     class: DetectorWindow
     description: Cut-out of the focal plane image with custom dimensions and coordinates
     include: True
@@ -36,75 +37,88 @@ effects :
         height: "!DET.height"
         units: pixel
 
--   name : qe_curve
-    description : Quantum efficiency curves for each detector
-    class : QuantumEfficiencyCurve
-    kwargs :
-        filename : QE_detector_H4RG.dat
+  - name: qe_curve
+    description: Quantum efficiency curves for each detector
+    class: QuantumEfficiencyCurve
+    kwargs:
+        filename: QE_detector_H4RG.dat
 
--   name: exposure_integration
+  - name: exposure_integration
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
--   name: dark_current
-    description : MICADO dark current
+  - name: dark_current
+    description: MICADO dark current
     class: DarkCurrent
     # [e-/s] level of dark current for each detector
     kwargs:
         value: 0.1
 
--   name: shot_noise
-    description : apply poisson shot noise to images
+  - name: shot_noise
+    description: apply poisson shot noise to images
     class: ShotNoise
 
--   name: detector_linearity
-    description : Linearity characteristics of H4RG chips
+  - name: detector_linearity
+    description: Linearity characteristics of H4RG chips
     class: LinearityCurve
     kwargs:
-        filename : FPA_linearity.dat
+        filename: FPA_linearity.dat
 
--   name: border_reference_pixels
+  - name: border_reference_pixels
     description: Blanks the signal on N edge row and column pixels
     class: ReferencePixelBorder
     kwargs:
         all: 0
 
--   name : readout_noise
-    description : Readout noise frames
-    class : PoorMansHxRGReadoutNoise
-    kwargs :
-        noise_std : 12
-        n_channels : 64
+  - name: readout_noise
+    description: Readout noise frames
+    class: PoorMansHxRGReadoutNoise
+    kwargs:
+        noise_std: 12
+        n_channels: 64
+
+  - name: exposure_output
+    description: Return average or sum over NDIT subexposures
+    class: ExposureOutput
+    kwargs:
+      mode: sum
+
+  - name: ad_conversion
+    description: Apply gain and convert electron counts into integers
+    class: ADConversion
+    kwargs:
+      dtype: float32
+      gain: "!DET.gain"
 
 # SourceDescriptionFitsKeywords are disabled by default because they still cause problems.
 # ValueError: The header keyword 'SIM SRC0 function_call' with its value is too long
 # "'scopesim_templates.stellar.clusters.cluster(mass=10000, distance=2000, core_radius=0.1, tidal_radius=None, multiplicity_object=None, seed=9001)'"
 # See also https://github.com/AstarVienna/ScopeSim_Templates/issues/69
 # and https://github.com/AstarVienna/ScopeSim_Templates/issues/70
--   name : source_fits_keywords
-    decription : adds meta data from Source object to FITS header
-    class : SourceDescriptionFitsKeywords
-    include : False
+  - name: source_fits_keywords
+    decription: adds meta data from Source object to FITS header
+    class: SourceDescriptionFitsKeywords
+    include: False
 
 # ValueError: The header keyword 'SIM EFF0 description' with its value is too long
 # "'atmospheric spectra pulled from the skycalc server'"
 #
-#-   name : effects_fits_keywords
-#    decription : adds meta dicts from all Effect objects to FITS header
-#    class : EffectsMetaKeywords
-#    include : True
+#-   name: effects_fits_keywords
+#    decription: adds meta dicts from all Effect objects to FITS header
+#    class: EffectsMetaKeywords
+#    include: True
 
 # ValueError: The header keyword 'SIM CONFIG SIM file server_base_url' with its value is too long
 # "'https://scopesim.univie.ac.at/InstPkgSvr/'"
 #
-#-   name : config_fits_keywords
-#    decription : adds all UserCommands dicts to FITS header
-#    class : SimulationConfigFitsKeywords
-#    include : True
+#-   name: config_fits_keywords
+#    decription: adds all UserCommands dicts to FITS header
+#    class: SimulationConfigFitsKeywords
+#    include: True
 
--   name : extra_fits_keywords
-    decription : adds extra FITS keywords from a yaml file
-    class : ExtraFitsKeywords
-    include : True
-    kwargs :
+  - name: extra_fits_keywords
+    decription: adds extra FITS keywords from a yaml file
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
       filename: FITS_extra_keywords.yaml


### PR DESCRIPTION
Keeping the mode for `ExposureOutput` as "sum" for now to hopefully not break the notebooks. This can be changed later.

How could the `ADConversion` get the gain value from `FPA_metis_img_lm_layout.dat`?

Also, some indentation fixing and spelling (When was the last time someone looked at this file? What's with all the commented-out stuff?).

Closes #238.