### PR TITLE
Add needs_scopesim keyword to MICADO

### DIFF
--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -1,22 +1,24 @@
 ---
 ### default observation parameters needed for a MICADO simulation
 
-object : configuration
-alias : OBS
-name : MICADO_default_configuration
-description : default parameters needed for a MICADO simulation
+object: configuration
+alias: OBS
+name: MICADO_default_configuration
+description: default parameters needed for a MICADO simulation
 status: development
-date_modified: 2023-07-13
+needs_scopesim: "v0.10.0b4"
+date_modified: 2025-06-27
 changes:
   - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits
+  - 2025-06-27 (FH) add needs_scopesim keyword
 
-packages :
+packages:
 - Armazones
 - ELT
 - MORFEO
 - MICADO
 
-yamls :
+yamls:
 - Armazones.yaml
 - ELT.yaml
 - MICADO.yaml


### PR DESCRIPTION
Using v0.10.0b4 because that has the `ExposureIntegration`.