### PR TITLE
Remove redundant !!float in yamls, fix others

### DIFF
--- a/HAWKI/HAWKI.yaml
+++ b/HAWKI/HAWKI.yaml
@@ -51,8 +51,7 @@ effects:
               - NB2090
           filename_format: "!INST.filter_file_format"
           current_filter: "!OBS.filter_name"
-          minimum_throughput: !!float 0.
+          minimum_throughput: 0.
           outer: 56                        # Based on MICADO filter sizes
           outer_unit: "mm"
           action: "transmission"
-

--- a/LFOA/LFOA.yaml
+++ b/LFOA/LFOA.yaml
@@ -50,7 +50,7 @@ effects :
     kwargs:
         filter_name: "!OBS.filter_name"
         filename_format: "filters/{}.dat"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.032
         outer_unit: "m"
 

--- a/METIS/METIS.yaml
+++ b/METIS/METIS.yaml
@@ -54,7 +54,7 @@ effects:
     include: True
     kwargs:
       transmission: "!OBS.pupil_transmission"
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
 
   - name : common_fits_keywords
     description : FITS keywords common to all modes

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -16,7 +16,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  full_well: !!float 1.E5   # electrons, E-TNT-MPIA-1004, v1-0
+  full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain:
     1: 2.0            # electrons/ADU, email B.Serra 2024-10-09
     2: 2.0

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -16,7 +16,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  full_well: !!float 1.E5   # electrons, E-TNT-MPIA-1004, v1-0
+  full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain: 2
   dark_current: 0.1         # [e-/s]
   readout_noise: 70         # electrons, AI on RvB: check

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -42,7 +42,7 @@ effects:
           description: "HAWAII2RG, fast mode"
           "!DET.mode": fast
           "!DET.mindit": 0.04
-          "!DET.full_well": !!float 1e5
+          "!DET.full_well": 1.e+5
           "!DET.gain": 4.0     # e/ADU (email B.Serra)
           "!DET.readout_noise": 70
           "!DET.dark_current": 0.05
@@ -50,7 +50,7 @@ effects:
           description: "HAWAII2RG, slow mode"
           "!DET.mode": slow
           "!DET.mindit": 1.3
-          "!DET.full_well": !!float 1e5
+          "!DET.full_well": 1.e+5
           "!DET.gain":  2.5    # e/ADU (email B.Serra)
           "!DET.readout_noise": 15
           "!DET.dark_current": 0.05

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -17,7 +17,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 0.008            # seconds, E-REP-NOVA-MET-1191, v2-0
-  full_well: !!float 1.e6  # electrons, low-capacity mode
+  full_well: 1.e+6  # electrons, low-capacity mode
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
   readout_noise: 12
   gain: 15    # wild guess to make full_well fit into int16
@@ -42,12 +42,12 @@ effects:
       mode_properties:
         low_gain:
           "!DET.mindit":    0.008        # seconds
-          "!DET.full_well": !!float 9e6  # electrons
+          "!DET.full_well": 9.e+6  # electrons
           "!DET.readout_noise": 1400     # electrons (DCS)
           "!DET.dark_current":  13       # electrons/second
         high_gain:
           "!DET.mindit":    0.008        # seconds
-          "!DET.full_well": !!float 1e6  # electrons
+          "!DET.full_well": 1.e+6  # electrons
           "!DET.readout_noise": 150      # electrons (DCS)
           "!DET.dark_current": 13        # electrons/second
 

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -42,22 +42,22 @@ effects:
           description:               "Geosnap, high-capacity mode"
           "!DET.mode":               "high_capacity"
           "!DET.mindit":             0.011          # seconds
-          "!DET.full_well":          !!float 2.8e6  # electrons
+          "!DET.full_well":          2.8e+6  # electrons
           "!DET.gain":               201            # electron/ADU (email B.Serra)
           "!DET.readout_noise":      300            # electrons (DCS)
-          "!DET.dark_current":       !!float 1e5    # electrons/second
-          "!DET.linearity.incident": [0, !!float 2.8e6, !!float 1e99]
-          "!DET.linearity.measured": [0, !!float 2.8e6, !!float 2.8e6]
+          "!DET.dark_current":       1.e+5    # electrons/second
+          "!DET.linearity.incident": [0, 2.8e+6, 1.e+99]
+          "!DET.linearity.measured": [0, 2.8e+6, 2.8e+6]
         low_capacity:
           description:               "Geosnap, low-capacity mode"
           "!DET.mode":               "low_capacity"
           "!DET.mindit":             0.011          # seconds
-          "!DET.full_well":          !!float 1.8e5  # electrons
+          "!DET.full_well":          1.8e+5  # electrons
           "!DET.gain":               14             # electron/ADU (email B.Serra)
           "!DET.readout_noise":      35             # electrons (DCS)
-          "!DET.dark_current":       !!float 1e5    # electrons/second
-          "!DET.linearity.incident": [0, !!float 1.8e5, !!float 1e99]
-          "!DET.linearity.measured": [0, !!float 1.8e5, !!float 1.8e5]
+          "!DET.dark_current":       1.e+5    # electrons/second
+          "!DET.linearity.incident": [0, 1.8e+5, 1.e+99]
+          "!DET.linearity.measured": [0, 1.8e+5, 1.8e+5]
 
   - name: quantum_efficiency
     description: Quantum efficiency curves for each detector

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -27,7 +27,7 @@ effects:
       filename: LIST_METIS_mirrors_img_lm.dat
 
   - name: filter_wheel
-    description: IMG_LM science filters (E-REP-MPIA-MET-1008_1-0)
+    description: "IMG_LM science filters (E-REP-MPIA-MET-1008_1-0)"
     class: FilterWheel
     kwargs:
       filter_names:
@@ -51,13 +51,13 @@ effects:
         - HCI_M
       filename_format: "!INST.filter_file_format"
       current_filter: "!OBS.filter_name"
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       outer: 56                               # E-REP-MPIA-MET-1008_1-0
       outer_unit: "mm"
 
   - name: nd_filter_wheel
     class: FilterWheel
-    description: IMG_LM neutral density filters (E-REP-MPIA-MET-1008_1-0)
+    description: "IMG_LM neutral density filters (E-REP-MPIA-MET-1008_1-0)"
     kwargs:
       filter_names:
         # 11 positions (E-REP-MPIA-MET-1008_1-0)
@@ -70,7 +70,7 @@ effects:
         - ND_OD5
       filename_format: "!INST.filter_file_format"
       current_filter: "!OBS.nd_filter_name"
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       outer: 56                                # E-REP-MPIA-MET-1008_1-0
       outer_unit: "mm"
 
@@ -98,5 +98,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 1E-3   # microns, defines fov wavelengths
-    spectral_resolution: 5000          # defines skycalc resolution
+    spectral_bin_width: 1.e-3  # microns, defines fov wavelengths
+    spectral_resolution: 5000  # defines skycalc resolution

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -25,7 +25,7 @@ effects:
       filename: LIST_METIS_mirrors_img_n.dat
 
   - name: filter_wheel
-    description: IMG_N science filters (E-REP-MPIA-MET-1008_1-0)
+    description: "IMG_N science filters (E-REP-MPIA-MET-1008_1-0)"
     class: FilterWheel
     kwargs:
       filter_names:
@@ -45,13 +45,13 @@ effects:
         - S_IV_ref
       filename_format: "!INST.filter_file_format"
       current_filter: "!OBS.filter_name"
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       outer: 56                        # E-REP-MPIA-MET-1008_1-0
       outer_unit: "mm"
 
   - name: nd_filter_wheel
     class: FilterWheel
-    description: IMG_N neutral density filters (E-REP-MPIA-MET-1008_1-0)
+    description: "IMG_N neutral density filters (E-REP-MPIA-MET-1008_1-0)"
     kwargs:
       filter_names:
         # 11 positions (E-REP-MPIA-MET-1008_1-0)
@@ -63,7 +63,7 @@ effects:
         - ND_OD4
       filename_format: "!INST.filter_file_format"
       current_filter: "!OBS.nd_filter_name"
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       outer: 56                  # E-REP-MPIA-MET-1008_1-0
       outer_unit: "mm"
 
@@ -92,5 +92,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 1E-3   # microns, defines fov wavelengths
-    spectral_resolution: 5000          # defines skycalc resolution
+    spectral_bin_width: 1.e-3  # microns, defines fov wavelengths
+    spectral_resolution: 5000  # defines skycalc resolution

--- a/METIS/METIS_LMS.yaml
+++ b/METIS/METIS_LMS.yaml
@@ -72,5 +72,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 1E-5   # microns, defines fov wavelengths
-    spectral_resolution: 200000          # defines skycalc resolution
+    spectral_bin_width: 1.e-5    # microns, defines fov wavelengths
+    spectral_resolution: 200000  # defines skycalc resolution

--- a/METIS/METIS_LMS_SMPL.yaml
+++ b/METIS/METIS_LMS_SMPL.yaml
@@ -63,5 +63,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: 1E-5  # microns, defines fov wavelengths
+    spectral_bin_width: 1.e-5    # microns, defines fov wavelengths
     spectral_resolution: 200000  # defines skycalc resolution

--- a/METIS/METIS_LSS.yaml
+++ b/METIS/METIS_LSS.yaml
@@ -50,5 +50,5 @@ description: RC simulation parameters which need to change for a METIS run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 5E-4   # microns, defines fov wavelengths
-    spectral_resolution: 5000          # defines skycalc resolution
+    spectral_bin_width: 5.e-4  # microns, defines fov wavelengths
+    spectral_resolution: 5000  # defines skycalc resolution

--- a/MICADO/MICADO.yaml
+++ b/MICADO/MICADO.yaml
@@ -13,11 +13,11 @@ alias : INST
 name : MICADO
 description : Effects from the MICADO common optics
 
-properties : 
+properties:
     temperature : -190
     filter_file_format : "filters/TC_filter_{}.dat"
 
-effects : 
+effects:
 -   name: micado_static_surfaces
     description : surfaces list for wide field optics
     class: SurfaceList
@@ -49,7 +49,7 @@ effects :
             - J-long
         filename_format: "!INST.filter_file_format"
         current_filter: "!OBS.filter_name_fw1"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.2
         outer_unit: "m"
 
@@ -75,7 +75,7 @@ effects :
             - xY1
         filename_format: "!INST.filter_file_format"
         current_filter: "!OBS.filter_name_fw2"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.2
         outer_unit: "m"
 
@@ -96,6 +96,6 @@ effects :
             - open
         filename_format: "!INST.filter_file_format"
         current_filter: "!OBS.filter_name_pupil"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.2
         outer_unit: "m"

--- a/MICADO/MICADO_SPEC.yaml
+++ b/MICADO/MICADO_SPEC.yaml
@@ -46,5 +46,5 @@ description: RC simulation parameters which need to change for a MICADO SPEC run
 
 properties:
   spectral:
-    spectral_bin_width: !!float 2E-5   # microns, defines fov wavelengths
-    spectral_resolution: 5000          # defines skycalc resolution
+    spectral_bin_width: 2.e-5  # microns, defines fov wavelengths
+    spectral_resolution: 5000  # defines skycalc resolution

--- a/MICADO_Sci/MICADO_Sci.yaml
+++ b/MICADO_Sci/MICADO_Sci.yaml
@@ -152,6 +152,6 @@ effects:
             - ND3
         filename_format: "!INST.filter_file_format"
         current_filter: "!OBS.filter_name"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.2
         outer_unit: "m"

--- a/OSIRIS/OSIRIS_LSS.yaml
+++ b/OSIRIS/OSIRIS_LSS.yaml
@@ -31,7 +31,7 @@ effects:
     class: FilterWheel
     include: True
     kwargs:
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       filename_format: "gratings/{}.txt"
       current_filter: "!OBS.grating_name"
       filter_names: "!INST.grism_names"

--- a/OSIRIS/OSIRIS_MAAT.yaml
+++ b/OSIRIS/OSIRIS_MAAT.yaml
@@ -33,7 +33,7 @@ effects:
     class: FilterWheel
     include: True
     kwargs:
-      minimum_throughput: !!float 0.
+      minimum_throughput: 0.
       filename_format: "gratings/{}.txt"
       current_filter: "!OBS.grating_name"
       filter_names: "!INST.grism_names"

--- a/ViennaLT/ViennaLT.yaml
+++ b/ViennaLT/ViennaLT.yaml
@@ -41,9 +41,6 @@ effects :
     kwargs:
         filter_name: "!OBS.filter_name"
         filename_format: "filters/{}.dat"
-        minimum_throughput: !!float 1.01E-4
+        minimum_throughput: 1.01e-4
         outer: 0.032
         outer_unit: "m"
-
-
-

--- a/WFC3/WFC3_IR.yaml
+++ b/WFC3/WFC3_IR.yaml
@@ -22,6 +22,6 @@ effects :
     kwargs:
         filter_name: "!OBS.filter_name"
         filename_format: "TER_filter_{}.dat"
-        minimum_throughput: !!float 1E-4
+        minimum_throughput: 1.e-4
         outer: 0.1
         outer_unit: "m"

--- a/docs/source/package_structure.rst
+++ b/docs/source/package_structure.rst
@@ -175,16 +175,3 @@ An example of a ``<package_name>.yaml`` file, note the ``filter_name`` property:
         class: TERCurve
         kwargs:
             filename: "!OBS.filter_name"
-
-
-Quick note on exponent notation floats in yaml files
-----------------------------------------------------
-.. note:: Preface floats like `1e6` in yaml files with the ``!!float`` keyword
-
-    ``pyyaml`` is generally pretty good at recognising variable types.
-    However, if you want to specify a value in exponent notation, i.e. ``4.2e1``
-    instead of ``42``, ``pyyaml`` will assume that you have written a string,
-    not a number. To override this, make sure to preface the number with the
-    ``pyyaml`` keyword ``!!float``. E.g.
-
-    ``power_in_watts: !!float 1.21e9``


### PR DESCRIPTION
Since forever, anything that has a decimal point and an explicit plus or minus in the exponent is converted to a float anyway, no need for this ugly tag. Also, "0." is converted to `0.0` anyway.

While in the process, I standardized on a lowercase "e". Both works fine and we had both before, but why not.