### PR TITLE
Replace optics_manager.surfaces_table.throughput

### DIFF
--- a/HAWKI/test_hawki/test_full_package_hawki.py
+++ b/HAWKI/test_hawki/test_full_package_hawki.py
@@ -80,8 +80,8 @@ class TestMakeOpticalTrain:
 
         # test that we have a system throughput
         wave = np.linspace(0.7, 2.5, 181) * u.um
-        tc = opt.optics_manager.surfaces_table.throughput
-        ec = opt.optics_manager.surfaces_table.emission
+        tc = opt.optics_manager.system_transmission
+        # ec = opt.optics_manager.surfaces_table.emission
         # ..todo:: something super wierd is going on here when running pytest in the top directory
         # ..todo:: perhaps this is has to be relaxed due to different filter
         # assert 0.5 < np.max(tc(wave)).value < 0.55
@@ -91,9 +91,9 @@ class TestMakeOpticalTrain:
             plt.plot(wave, tc(wave))
             plt.show()
 
-        if PLOTS:
-            plt.plot(wave, ec(wave))
-            plt.show()
+        # if PLOTS:
+        #     plt.plot(wave, ec(wave))
+        #     plt.show()
 
         # test that we have the correct number of FOVs for Ks band
         # assert len(opt.fov_manager.fovs) == 18

--- a/LFOA/tests/test_lfoa.py
+++ b/LFOA/tests/test_lfoa.py
@@ -38,7 +38,7 @@ class TestObserves:
         if PLOTS:
             plt.subplot(121)
             wave = np.arange(3000, 11000)
-            plt.plot(wave, lfoa.optics_manager.surfaces_table.throughput(wave))
+            plt.plot(wave, lfoa.optics_manager.system_tranmission(wave))
 
             plt.subplot(122)
             im = hdus[0][1].data

--- a/ViennaLT/tests/test_lvilt.py
+++ b/ViennaLT/tests/test_lvilt.py
@@ -39,7 +39,7 @@ class TestObserves:
         if PLOTS:
             plt.subplot(121)
             wave = np.arange(3000, 11000)
-            plt.plot(wave, lfoa.optics_manager.surfaces_table.throughput(wave))
+            plt.plot(wave, lfoa.optics_manager.system_transmission(wave))
 
             plt.subplot(122)
             im = hdus[0][1].data

--- a/WFC3/test_wfc3/test_full_package_wfc3_ir.py
+++ b/WFC3/test_wfc3/test_full_package_wfc3_ir.py
@@ -85,8 +85,8 @@ class TestMakeOpticalTrain:
 
         # test that we have a system throughput
         wave = np.linspace(0.7, 1.8, 111) * u.um
-        tc = opt.optics_manager.surfaces_table.throughput
-        ec = opt.optics_manager.surfaces_table.emission
+        tc = opt.optics_manager.system_transmission
+        # ec = opt.optics_manager.surfaces_table.emission
         # ..todo:: something super wierd is going on here when running pytest in the top directory
         assert 0.4 < np.max(tc(wave)) < 0.6
 
@@ -94,9 +94,9 @@ class TestMakeOpticalTrain:
             plt.plot(wave, tc(wave))
             plt.show()
 
-        if PLOTS:
-            plt.plot(wave, ec(wave))
-            plt.show()
+        # if PLOTS:
+        #     plt.plot(wave, ec(wave))
+        #     plt.show()
 
         # test that we have the correct number of FOVs for Ks band
         assert len(opt.fov_manager.fovs) == 1


### PR DESCRIPTION
With optics_manager.system_transmission, in all tests that used it.

Fixes #255.