### PR TITLE
FITS keyword values Boolean rather than string

### DIFF
--- a/METIS/headers/FITS_common_keywords.yaml
+++ b/METIS/headers/FITS_common_keywords.yaml
@@ -81,7 +81,7 @@
             NAME: "TODO"
           CUBE:
             # TODO: Allow cube mode in ScopeSim.
-            MODE: "F"
+            MODE: false
         INS:
           # Keywords from the instrument subsystem.
           #
@@ -151,7 +151,7 @@
 - ext_type: ImageHDU
   # Keyword for extension HDUs.
   keywords:
-    INHERIT: "T"
+    INHERIT: true
     # Will resolve to e.g. DET1.DATA, DET2.DATA etc. This allows us to reorder
     # the extensions in case they are shuffled.
     EXTNAME: "DET§.DATA"

--- a/METIS/headers/FITS_det_ifu_keywords.yaml
+++ b/METIS/headers/FITS_det_ifu_keywords.yaml
@@ -6,7 +6,7 @@
           DIT:        "!OBS.dit"
           NDIT:       "!OBS.ndit"
           CUBE:
-            MODE:     "F"
+            MODE:     false
 
 - ext_number: [1]
   keywords:

--- a/METIS/headers/FITS_det_lm_keywords.yaml
+++ b/METIS/headers/FITS_det_lm_keywords.yaml
@@ -7,7 +7,7 @@
           NDIT:       "!OBS.ndit"
           MODE:       "!DET.mode"
           CUBE:
-            MODE:    "F"
+            MODE:    false
 
 - ext_type: ImageHDU
   keywords:

--- a/METIS/headers/FITS_det_n_keywords.yaml
+++ b/METIS/headers/FITS_det_n_keywords.yaml
@@ -7,7 +7,7 @@
           NDIT:       "!OBS.ndit"
           MODE:       "!DET.mode"
           CUBE:
-            MODE:    "F"
+            MODE:    false
         SEQ:
           CHOPNOD:
             ST:      "#chop_nod.include"

--- a/METIS/tests/test_metis.py
+++ b/METIS/tests/test_metis.py
@@ -280,3 +280,7 @@ class TestObserves:
             plt.show()
 
         assert mx > med + 3 * std
+
+        # This should not be here, but putting it into a separate test would work
+        # better if the simulation were done in a fixture
+        assert isinstance(hdus[0][1].header["INHERIT"], bool)

--- a/MICADO/FITS_extra_keywords.yaml
+++ b/MICADO/FITS_extra_keywords.yaml
@@ -112,6 +112,6 @@
             ALL: "#border_reference_pixels.all"
 - ext_type: ImageHDU
   keywords:
-    INHERIT: "T"
+    INHERIT: true
     # Will resolve to e.g. DET1.DATA, DET2.DATA etc., as required by ESO.
     EXTNAME: "DET§.DATA"


### PR DESCRIPTION
Fixes #269 . All obvious occurrences of `"T"`/`"F"` in METIS and MICADO yamls have been replaced by `true`/`false`. This may have missed some indirect/imported occurrences - we need to keep an eye on this.