### PR TITLE
Rename no lamp state from none to off

### DIFF
--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -428,7 +428,7 @@
     "The default configuration for the WCU is read from the file `metis_wcu_config.yaml` in the METIS instrument package. This is a yaml file that contains both the user-settable parameters described above and also physical quantities that describe the WCU itself:\n",
     "```yaml\n",
     "# ------------- User-settable parameters\n",
-    "lamps:  [\"bb\", \"laser\", \"none\"]  # available lamps\n",
+    "lamps:  [\"bb\", \"laser\", \"off\"]  # available lamps\n",
     "current_lamp: \"bb\"  # the lamp currently in use\n",
     "bb_temp: 1000       # [K] temperature of BB source  # Kelvin!\n",
     "is_temp:  300       # [K] temperature of the integratig sphere\n",
@@ -491,7 +491,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.7"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -1,5 +1,5 @@
 # ------------- User-settable parameters
-lamps:  ["bb", "laser", "none"]  # available lamps
+lamps:  ["bb", "laser", "off"]  # available lamps
 current_lamp: "bb"  # the lamp currently in use
 bb_temp: 1000       # [K] temperature of BB source  # Kelvin!
 is_temp:  300       # [K] temperature of the integratig sphere


### PR DESCRIPTION
The original name "none" was converted to None somewhere. The new term "off" should be safe.

cf. https://github.com/AstarVienna/ScopeSim/issues/834