### PR TITLE
Fix definition of `ReferencePixelBorder` in all packages after API change

### DIFF
--- a/MICADO/FITS_extra_keywords.yaml
+++ b/MICADO/FITS_extra_keywords.yaml
@@ -142,7 +142,7 @@
           #   NOISESTD: "#readout_noise.noise_std"
           #   NCHANNEL: "#readout_noise.n_channels"
           REF:
-            ALL: "#border_reference_pixels.all"
+            NPIX: "#border_reference_pixels.border"
 - ext_type: ImageHDU
   keywords:
     INHERIT: true

--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -68,7 +68,7 @@ effects:
     description: Blanks the signal on N edge row and column pixels
     class: ReferencePixelBorder
     kwargs:
-        all: 0
+      border: [0, 0, 0, 0]
 
   - name: readout_noise
     description: Readout noise frames

--- a/MOSAIC/MOSAIC_DET_NIR.yaml
+++ b/MOSAIC/MOSAIC_DET_NIR.yaml
@@ -70,7 +70,7 @@ effects:
     description: Blanks the signal on N edge row and column pixels
     class: ReferencePixelBorder
     kwargs:
-      all: 0
+      border: [0, 0, 0, 0]
 
   - name: readout_noise
     description: Readout noise frames

--- a/OSIRIS/OSIRIS_DET.yaml
+++ b/OSIRIS/OSIRIS_DET.yaml
@@ -62,8 +62,7 @@ effects :
     description: Blanks the signal on N edge row and column pixels
     class: ReferencePixelBorder
     kwargs:
-        left:  50
-#        right: 50 #New CCD only has prescan, no overscan
+      border: [0, 50, 0, 0]
 
   - name : readout_noise
     description : Readout noise frames


### PR DESCRIPTION
... as a result of AstarVienna/ScopeSim#840.