### PR TITLE
Add fake !ATMO.location to HST and JWST packages

### DIFF
--- a/HST/HST.yaml
+++ b/HST/HST.yaml
@@ -13,3 +13,9 @@ effects :
     class : SurfaceList
     kwargs :
         filename : LIST_mirrors_HST.tbl
+
+---
+alias: ATMO
+description: "Fake !ATMO.location to avoid confusing ScopeSim"
+properties:
+  location: Space

--- a/JWST/JWST.yaml
+++ b/JWST/JWST.yaml
@@ -13,3 +13,9 @@ effects:
     class: SurfaceList
     kwargs:
       filename: LIST_mirrors_JWST.tbl
+
+---
+alias: ATMO
+description: "Fake !ATMO.location to avoid confusing ScopeSim"
+properties:
+  location: Space


### PR DESCRIPTION
This avoids a non-critical error seen in `OpticalTrain.readout()`.