### PR TITLE
Swap LMS detectors 1 and 2

### DIFF
--- a/METIS/FPA_metis_lms_layout.dat
+++ b/METIS/FPA_metis_lms_layout.dat
@@ -2,7 +2,7 @@
 # author : Oliver Czoske
 # sources: E-REP-ATC-MET-1003_1
 # date_created : 2019-08-18
-# date_modified : 2022-04-22
+# date_modified : 2026-01-22
 # type : detector:chip_list
 # x_cen_unit : mm
 # y_cen_unit : mm
@@ -18,9 +18,10 @@
 # - 2020-02-03 (OC) updated meta data to new format
 # - 2020-07-22 (KL) added image_plane_id = 0
 # - 2022-04-22 (OC) changed column names from _len to _size, removed columns xhw, yhw
+# - 2026-01-22 (OC) swap dets 1 and 2 as requested by A Glasse
 #
 id  x_cen    y_cen     x_size  y_size  pixel_size  angle   gain
- 1  +19.547  +19.547   2048    2048    0.018       0.0     1.0
- 2  -19.547  +19.547   2048    2048    0.018       0.0     1.0
+ 1  -19.547  +19.547   2048    2048    0.018       0.0     1.0
+ 2  +19.547  +19.547   2048    2048    0.018       0.0     1.0
  3  -19.547  -19.547   2048    2048    0.018       0.0     1.0
  4  +19.547  -19.547   2048    2048    0.018       0.0     1.0

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -4,11 +4,12 @@ object: detector
 alias: DET
 name: metis_lms_detector_array
 description: A set of 4 H2RG detectors
-date_modified: 2025-06-16
+date_modified: 2026-01-22
 changes:
   - 2021-12-16 (OC) some rearrangements
   - 2024-10-11 (OC) add ADConversion, gain from B.Serra (2024-10-09)
   - 2025-06-16 (OC) rename SummedExposure to ExposureIntegration
+  - 2026-01-22 (OC) swap dets 1 and 2 as in the layout
 
 properties:
   image_plane_id: 0
@@ -31,8 +32,8 @@ properties:
   linearity:
     file_name: "FPA_linearity_HxRG.dat"
   border:
-    1: [32, 0, 32, 64]
-    2: [32, 64, 32, 0]
+    1: [32, 64, 32, 0]
+    2: [32, 0, 32, 64]
     3: [32, 64, 32, 0]
     4: [32, 0, 32, 64]
 

--- a/METIS/docs/example_notebooks/demos/demo_reference_pixel_mask.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_reference_pixel_mask.ipynb
@@ -178,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "_, [[ax2, ax1], [ax3, ax4]] = plt.subplots(2, 2, layout=\"tight\", sharex=True, sharey=True)\n",
+    "_, [[ax1, ax2], [ax3, ax4]] = plt.subplots(2, 2, layout=\"tight\", sharex=True, sharey=True)\n",
     "ax1.imshow(readout[1].data)\n",
     "ax2.imshow(readout[2].data)\n",
     "ax3.imshow(readout[3].data)\n",


### PR DESCRIPTION
As requested by Alistair Glasse, this pull request swaps detectors 1 and 2 in the detector plane. The layout is now
|1 | 2|
|-|-|
|3 |4|

with traces horizontally. The reference border definitions have been adjusted accordingly.