### PR TITLE
Give hole positions explicitely as float values

### DIFF
--- a/METIS/wcu/fp_mask_pinhole_lm.dat
+++ b/METIS/wcu/fp_mask_pinhole_lm.dat
@@ -3,7 +3,7 @@
 # author : Oliver Czoske
 # source : E-SPE-UZK-MET-1015_2-0; E-REP-UZK-MET-1008_3-0, Table 10-8
 # date_created : 2025-01-13
-# date_modified : 2025-01-13
+# date_modified : 2026-01-23
 # status : FDR
 # type : aperture:aperture_mask
 # x_unit : arcsec
@@ -11,6 +11,7 @@
 # diam_unit : arcsec
 # notes: diam 25 um at 3.319 mm/arcsec
 # changes :
+#  - 2026-01-23 (OC) x and y explicitely float values
 #
  x   y    diam
- 0   0    0.007532
+ 0.  0.   0.007532

--- a/METIS/wcu/fp_mask_pinhole_n.dat
+++ b/METIS/wcu/fp_mask_pinhole_n.dat
@@ -3,7 +3,7 @@
 # author : Oliver Czoske
 # source : E-SPE-UZK-MET-1015_2-0; E-REP-UZK-MET-1008_3-0, Table 10-8
 # date_created : 2025-01-13
-# date_modified : 2025-01-13
+# date_modified : 2026-01-23
 # status : FDR
 # type : aperture:aperture_mask
 # x_unit : arcsec
@@ -11,6 +11,7 @@
 # diam_unit : arcsec
 # notes: diam 66 um at 3.319 mm/arcsec
 # changes :
+#  - 2026-01-23 (OC) x and y explicitely float values
 #
  x   y    diam
- 0   0    0.01988551
+ 0.  0.    0.01988551


### PR DESCRIPTION
Hole positions (in the METIS WCU focal-plane masks) do not have to be integer. While AstarVienna/ScopeSim#869 does convert to float internally, this PR sets the pinhole positions to (0., 0.), i.e. explicitely as float. This is also a quicker fix to AstarVienna/ScopeSim#868 while awaiting the next release of scopesim.

Fixes AstarVienna/ScopeSim#868