### PR TITLE
Run METIS demo notebooks as separate job

### DIFF
--- a/.github/workflows/notebooktests.yml
+++ b/.github/workflows/notebooktests.yml
@@ -146,14 +146,40 @@ jobs:
           PYDEVD_DISABLE_FILE_VALIDATION: 1
         run: |
           echo "## METIS Notebooks tested" >> $GITHUB_STEP_SUMMARY
-          echo "### Example Notebooks" >> $GITHUB_STEP_SUMMARY
           for fn in METIS/docs/example_notebooks/*.ipynb
           do
             echo "${fn}"
             echo "- ${fn}" >> $GITHUB_STEP_SUMMARY
             /usr/bin/time -v jupytext --execute --update "${fn}"
           done
-          echo "## Demo Notebooks" >> $GITHUB_STEP_SUMMARY
+
+  metis_demo_notebooks:
+    name: Run METIS Demo Notebooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          # No matrix is used since this is a time-consuming task.
+          python-version: 3.13
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.github_actions.txt
+
+      - name: Install ScopeSim from repo
+        if: ${{ inputs.from_pypi == false || inputs.from_pypi == 'false' }}
+        run: |
+          echo "Re-installing ScopeSim from source" >> $GITHUB_STEP_SUMMARY
+          pip uninstall -y scopesim scopesim_templates
+          pip install git+https://github.com/AstarVienna/ScopeSim.git@${{ inputs.ScopeSim }}
+          pip install git+https://github.com/AstarVienna/ScopeSim_Templates.git@${{ inputs.ScopeSim_Templates }}
+      - name: Run Notebooks
+        env:
+          PYDEVD_DISABLE_FILE_VALIDATION: 1
+        run: |
+          echo "## METIS Demo Notebooks tested" >> $GITHUB_STEP_SUMMARY
           for fn in METIS/docs/example_notebooks/demos/*.ipynb
           do
             echo "${fn}"


### PR DESCRIPTION
The smaller "demo" notebooks are independent of the larger "example" notebooks. Running them as a separate job (and thus in parallel) reduces the overall runtime of the notebooktests CI by a few minutes.