### PR TITLE
Add validation test results to docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,9 +5,14 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.11"
+  jobs:
+    post_install:
+      - pytest ./MICADO/test_micado/ -m validation --junit-xml=./MICADO/test_micado/validation_results.xml --tb=line -o junit_suite_name=MICADO || true
+      # - pytest ./METIS/tests/ -m validation --junit-xml=./METIS/tests/validation_results.xml --tb=line -o junit_suite_name=METIS || true
+      # - pytest ./MOSAIC/tests/ -m validation --junit-xml=./MOSAIC/tests/validation_results.xml --tb=line -o junit_suite_name=MOSAIC || true
 
 sphinx:
    configuration: conf.py

--- a/MICADO/docs/readme.rst
+++ b/MICADO/docs/readme.rst
@@ -94,6 +94,7 @@ Green (passed) means a result within the given tolerances, yellow (xfailed) mean
 
 .. validation-report:: ./MICADO/test_micado/validation_results.xml
 
+The code used to generate these results can be found in this `GitHub folder <https://github.com/AstarVienna/irdb/tree/dev_master/MICADO/test_micado/>`_.
 
 Documentation and useful references
 -----------------------------------

--- a/MICADO/docs/readme.rst
+++ b/MICADO/docs/readme.rst
@@ -85,6 +85,14 @@ Scientific use-case notebooks
    * - <add title>
      - <add description>
 
+Validation
+----------
+The following table shows an overview of the test results for limiting magnitudes assuming a minimal signal-to-noise ration of 5.
+Green (passed) means a result within the given tolerances, yellow (xfailed) means an *expected* deviation, red (failed) means an *unexpected* issue.
+
+**Click** on each row for a plot of the test results.
+
+.. validation-report:: ./MICADO/test_micado/validation_results.xml
 
 
 Documentation and useful references

--- a/MICADO/test_micado/test_micado_imaging.py
+++ b/MICADO/test_micado/test_micado_imaging.py
@@ -11,24 +11,28 @@ Comments
 
 """
 
-# integration test using everything and the MICADO package
+import os
 from pathlib import Path
 import pytest
 from pytest import approx
 
 import numpy as np
+from scipy.stats import linregress
+import matplotlib as mpl
+from matplotlib import pyplot as plt
 
 import scopesim as sim
 from scopesim import rc
 from scopesim.source import source_templates as st
 
-from matplotlib import pyplot as plt
 
 PATH_HERE = Path(__file__).parent
 PATH_IRDB = PATH_HERE.parent.parent
 
 rc.__config__["!SIM.file.local_packages_path"] = str(PATH_IRDB)
-PLOTS = False
+PLOTS = os.environ.get("READTHEDOCS", False)  # Run plots on RTD
+if PLOTS:
+    mpl.style.use("seaborn-v0_8")
 
 
 @pytest.mark.validation
@@ -68,12 +72,14 @@ class TestLimiting:
             pytest.param(
                 "J", "open", 1, 27.9, 0.3,
                 marks=pytest.mark.xfail(
+                    not os.environ.get("READTHEDOCS"),
                     reason="something changed in ScopeSim..."
                     ),
                 ),
             pytest.param(
                 "open", "H", 2, 27.5, 0.3,
                 marks=pytest.mark.xfail(
+                    not os.environ.get("READTHEDOCS"),
                     reason="something changed in ScopeSim..."
                     ),
                 ),
@@ -81,97 +87,150 @@ class TestLimiting:
         ],
     )
     def test_MCAO_IMG_4mas(
-        self, fw1, fw2, r0, rics_lim_mag, abslim, ao_mode="MCAO"
+        self, record_property, fw1, fw2, r0, rics_lim_mag, abslim, ao_mode="MCAO", img_mode="IMG_4mas",
     ):
+        filt = fw1 if fw1 != "open" else fw2
+        record_property("filter", filt)
+        record_property("ao_mode", ao_mode)
+        record_property("img_mode", img_mode)
+        record_property("expected", rics_lim_mag)
+        record_property("tolerance", abslim)
 
         n_stars, mmin, mmax = 400, 25, 30
         r1, r2 = 10, 15  # aperture radii  r0 (sig), r1-r2 (noise)
         src = st.star_field(n_stars, mmin, mmax, width=3, use_grid=True)
 
         cmds = sim.UserCommands(
-            use_instrument="MICADO", set_modes=[ao_mode, "IMG_4mas"]
+            use_instrument="MICADO", set_modes=[ao_mode, img_mode]
         )
         micado = sim.OpticalTrain(cmds)
-        micado.cmds["!OBS.dit"] = 18000
+        micado.cmds["!OBS.dit"] = 18000  # 5 h
         micado["filter_wheel_1"].change_filter(fw1)
         micado["filter_wheel_2"].change_filter(fw2)
         micado["detector_linearity"].include = False
 
         micado.observe(src)
-        hdul = micado.readout()[0]
-
-        det = hdul[1].data
+        det = micado.readout()[0][1].data
         imp = micado.image_planes[0].hdu.data  # e-/pixel/s
-        if PLOTS:
-            plt.subplot(131)
-            plt.imshow(imp, norm="log", vmin=np.median(imp),
-                       vmax=1.01*np.median(imp))
 
-            plt.subplot(132)
-            plt.imshow(det, norm="log", vmin=np.median(det),
-                       vmax=1.01*np.median(det))
+        if PLOTS:
+            fig, (img_ax, det_ax, snr_ax) = plt.subplots(1, 3, figsize=(20, 8), layout="constrained")
+            fig.suptitle(f"MICADO {ao_mode} {img_mode} {filt}-band")
+
+            img_ax.imshow(
+                imp,
+                norm="log",
+                vmin=np.median(imp),
+                vmax=np.quantile(imp, .995),
+                origin="lower",
+                cmap="inferno",
+            )
+            img_ax.set_title("Image Plane")
+            img_ax.grid(False, which="both")
+            img_ax.set_xlabel("pixel")
+            img_ax.set_ylabel("pixel")
+            det_ax.imshow(
+                det,
+                norm="log",
+                vmin=np.median(det),
+                vmax=np.quantile(det, .998),
+                origin="lower",
+                cmap="inferno",
+            )
+            det_ax.set_title("Detector")
+            det_ax.grid(False, which="both")
+            det_ax.set_xlabel("pixel")
+            det_ax.set_ylabel("pixel")
+
+        midpoint_x = micado.cmds["!DET.width"] // 2
+        midpoint_y = micado.cmds["!DET.height"] // 2
 
         xpix, ypix = src.fields[0].field["x"].data, src.fields[0].field["y"].data
-        xpix = xpix / 0.004 + 512
-        ypix = ypix / 0.004 + 512
+        xpix = (xpix / micado.cmds["!INST.pixel_scale"] + midpoint_x).round(2)
+        ypix = (ypix / micado.cmds["!INST.pixel_scale"] + midpoint_y).round(2)
+
+        # For some bizzare reason, this is the only way the apertures end up in
+        # the correct position??
+        xpix = np.where(
+            xpix < midpoint_x,
+            np.floor(xpix),
+            np.ceil(xpix)
+        ).astype(int)
+        ypix = np.where(
+            ypix < midpoint_y,
+            np.floor(ypix),
+            np.ceil(ypix)
+        ).astype(int)
+
         mags = np.round(np.linspace(mmin, mmax, n_stars), 1)
+        snrs = np.array(list(self._photometry(xpix, ypix, mags, r0, r1, r2, det)))
 
-        snrs = []
-        for x, y, mag in zip(xpix, ypix, mags):
-            # For some bizzare reason, this is the only way the apertures end
-            # up in the correct position??
-            if x < 512:
-                x = np.floor(np.round(x, 2)).astype(int)
-            else:
-                x = np.ceil(np.round(x, 2)).astype(int)
-            if y < 512:
-                y = np.floor(np.round(y, 2)).astype(int)
-            else:
-                y = np.ceil(np.round(y, 2)).astype(int)
-
-            sig_im = np.copy(det[y-r0:y+r0+1, x-r0:x+r0+1])
-            bg_im  = np.copy(det[y-r2:y+r2+1, x-r2:x+r2+1])
-            bg_im[r1:-r1, r1:-r1] = 0
-
-            bg_median = np.median(bg_im[bg_im > 0])
-            bg_std = np.std(bg_im[bg_im > 0])
-            # bg_std = np.sqrt(bg_median)
-            noise = bg_std * np.sqrt(np.prod(sig_im.shape)) * np.sqrt(2)        # sqrt(2) comes from BG subtraction (see Rics doc)
-            signal = np.sum(sig_im - bg_median)
-            snr = signal / noise
-            snrs += [snr]
-
-            if PLOTS:
-                plt.plot([x-r0, x+r0, x+r0, x-r0, x-r0],
-                         [y-r0, y-r0, y+r0, y+r0, y-r0], "g")
-                plt.plot([x-r1, x+r1, x+r1, x-r1, x-r1],
-                         [y-r1, y-r1, y+r1, y+r1, y-r1], "y")
-                plt.plot([x-r2, x+r2, x+r2, x-r2, x-r2],
-                         [y-r2, y-r2, y+r2, y+r2, y-r2], "r")
-
-                plt.text(x+r2, y+r2, str(round(snr, 1)), color="w")
-                plt.text(x-r2, y-r2, str(mag), color="w")
-
-        from scipy.stats import linregress
-        snrs = np.array(snrs)
-        results = linregress(mags[snrs > 5], np.log10(snrs[snrs > 5]))
-        m, c = results[:2]
-        sigma = 5
-        lim_mag = (np.log10(sigma) - c) / m
+        snr_limit = 5
+        lin_fit = linregress(mags[snrs > snr_limit], np.log10(snrs[snrs > snr_limit]))
+        lim_mag = (np.log10(snr_limit) - lin_fit.intercept) / lin_fit.slope
 
         if PLOTS:
-            plt.subplot(133)
-            plt.plot(mags, snrs, ".", alpha=0.3)
-            plt.plot(mags, 10 ** (m * mags + c), "r")
+            snr_ax.plot(mags, snrs, ".", alpha=0.5, label="Measurements")
+            snr_ax.plot(mags, 10 ** (lin_fit.slope * mags + lin_fit.intercept), label="Fit")
 
-            plt.axhline(sigma)
-            plt.axvline(lim_mag)
-            plt.text(lim_mag, sigma, str(lim_mag),
-                     horizontalalignment="left",
-                     verticalalignment="bottom")
+            snr_ax.axhline(snr_limit, linestyle=":", color="#64B5CD", alpha=.7, label=f"S/N={snr_limit} limit")
+            snr_ax.axvline(lim_mag, linestyle="--", color="#C44E52", alpha=.7, label=f"Limiting Mag.e @ S/N={snr_limit}")
+            snr_ax.axvline(rics_lim_mag, color="#CCB974", alpha=.8, zorder=-1, label=f"Expected value\n{rics_lim_mag} +/- {abslim} mag")
+            snr_ax.axvspan(rics_lim_mag - abslim, rics_lim_mag + abslim, color="#CCB974", alpha=.2)
+            snr_ax.text(
+                lim_mag + .1,
+                snr_limit + .5,
+                f"{lim_mag:.2f}",
+                horizontalalignment="left",
+                verticalalignment="bottom",
+                fontsize=16,
+                color="#C44E52",
+            )
+            snr_ax.set_xlabel("mag")
+            snr_ax.set_ylabel("S/N")
+            snr_ax.legend()
+            snr_ax.set_title(f"S/N for MICADO {ao_mode} {img_mode}")
+
+            fig_path = PATH_IRDB / f"docs/source/_static/plots/MICADO/limmag/{ao_mode}_{img_mode}_{filt}.pdf"
+            fig_path.parent.mkdir(parents=True, exist_ok=True)
+            fig.savefig(fig_path)
+            record_property("link", str(fig_path.relative_to(PATH_IRDB / "docs/source")))
 
             plt.show()
 
-        # J-band fails because ScopeSIm is 0.5 mags lower Ric's estimate. Why?!?
         print(f"expected: {rics_lim_mag:.2f}, obtained: {lim_mag:.2f}, delta: {lim_mag-rics_lim_mag:.3f}")
+        record_property("obtained", round(lim_mag, 2))
+        record_property("difference", round(lim_mag-rics_lim_mag, 3))
+
+        lim_mag = round(lim_mag, 4)  # for nicer output msg
         assert lim_mag == approx(rics_lim_mag, abs=abslim)
+
+    @staticmethod
+    def _photometry(xpix, ypix, mags, r0, r1, r2, det):
+        for x, y, mag in zip(xpix, ypix, mags):
+            sig_im = np.copy(det[y-r0:y+r0+1, x-r0:x+r0+1])
+            bkg_im = np.copy(det[y-r2:y+r2+1, x-r2:x+r2+1])
+            bkg_im[r1:-r1, r1:-r1] = 0  # use masked array?
+
+            bg_median = np.median(bkg_im[bkg_im > 0])
+            bg_std = np.std(bkg_im[bkg_im > 0])
+            # bg_std = np.sqrt(bg_median)
+            noise = bg_std * np.sqrt(np.prod(sig_im.shape)) * np.sqrt(2)  # sqrt(2) comes from BG subtraction (see Rics doc)
+            signal = np.sum(sig_im - bg_median)
+            snr = signal / noise
+
+            if PLOTS:
+                # Can't pass det_ax as an argument if it doesn't always exits.
+                # Whatever, this works...
+                _, det_ax, _ = plt.gcf().get_axes()
+                det_ax.plot([x-r0, x+r0, x+r0, x-r0, x-r0],
+                            [y-r0, y-r0, y+r0, y+r0, y-r0], "g")
+                det_ax.plot([x-r1, x+r1, x+r1, x-r1, x-r1],
+                            [y-r1, y-r1, y+r1, y+r1, y-r1], "y")
+                det_ax.plot([x-r2, x+r2, x+r2, x-r2, x-r2],
+                            [y-r2, y-r2, y+r2, y+r2, y-r2], "r")
+
+                det_ax.text(x+r2, y+r2, f"{snr:.1f}", color="w")
+                det_ax.text(x-r2, y-r2, f"{mag:.1f}", color="w")
+
+            yield snr

--- a/MICADO/test_micado/test_micado_imaging.py
+++ b/MICADO/test_micado/test_micado_imaging.py
@@ -31,6 +31,7 @@ rc.__config__["!SIM.file.local_packages_path"] = str(PATH_IRDB)
 PLOTS = False
 
 
+@pytest.mark.validation
 class TestLimiting:
     """
     from Ric's excel doc (Signal_noise_estimator_MICADO_2018.04.03)

--- a/MICADO/test_micado/test_micado_imaging.py
+++ b/MICADO/test_micado/test_micado_imaging.py
@@ -67,27 +67,32 @@ class TestLimiting:
 
     """
 
+    @pytest.mark.parametrize("img_mode", ["IMG_4mas"])
+    @pytest.mark.parametrize("ao_mode", ["MCAO", "SCAO"])
     @pytest.mark.parametrize(
         ("fw1", "fw2", "r0", "rics_lim_mag", "abslim"), [
             pytest.param(
-                "J", "open", 1, 27.9, 0.3,
+                "J", "open", 1, 27.9, 1.0,
                 marks=pytest.mark.xfail(
-                    not os.environ.get("READTHEDOCS"),
-                    reason="something changed in ScopeSim..."
-                    ),
+                    reason="most likely PSF contamination of nearby sources"
                 ),
+            ),
             pytest.param(
-                "open", "H", 2, 27.5, 0.3,
+                "open", "H", 2, 27.5, 0.6,
                 marks=pytest.mark.xfail(
-                    not os.environ.get("READTHEDOCS"),
-                    reason="something changed in ScopeSim..."
-                    ),
+                    reason="most likely PSF contamination of nearby sources"
                 ),
-            ("open", "Ks", 2, 27.1, 0.3),
+            ),
+            pytest.param(
+                "open", "Ks", 2, 27.1, 0.3,
+                marks=pytest.mark.xfail(
+                    reason="most likely PSF contamination of nearby sources"
+                ),
+            ),
         ],
     )
     def test_MCAO_IMG_4mas(
-        self, record_property, fw1, fw2, r0, rics_lim_mag, abslim, ao_mode="MCAO", img_mode="IMG_4mas",
+        self, record_property, fw1, fw2, r0, rics_lim_mag, abslim, ao_mode, img_mode,
     ):
         filt = fw1 if fw1 != "open" else fw2
         record_property("filter", filt)

--- a/conf.py
+++ b/conf.py
@@ -177,6 +177,9 @@ html_favicon = 'docs/source/_static/logos/T_favicon.png'
 html_css_files = [
     "validation_report.css",
 ]
+html_js_files = [
+    "clickable_rows.js",
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/conf.py
+++ b/conf.py
@@ -174,7 +174,9 @@ html_theme_options = {"body_max_width": "900px"}
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['docs/source/_static']      # 'METIS/docs/example_notebooks'
 html_favicon = 'docs/source/_static/logos/T_favicon.png'
-
+html_css_files = [
+    "validation_report.css",
+]
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/conf.py
+++ b/conf.py
@@ -56,6 +56,7 @@ extensions = [
     # 'sphinx.ext.autodoc',
     # 'jupyter_sphinx.execute',
     # 'sphinxcontrib.apidoc',
+    "docs.source._ext.validation_report",
 ]
 
 # numpydoc settings

--- a/docs/source/_ext/validation_report.py
+++ b/docs/source/_ext/validation_report.py
@@ -1,0 +1,185 @@
+# -*- coding: utf-8 -*-
+"""Custom extension to parse pytest report on validation tests."""
+
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+from docutils import nodes
+from docutils.parsers.rst import Directive
+
+
+class ValidationReport:
+    """XML Parser for Validation Report from Pytest."""
+
+    def __init__(self, xml_path):
+        tree = ET.parse(Path(xml_path))
+        root = tree.getroot()
+        self.suite = root.find("testsuite")  # only one suit per file supported
+        self.name = self.suite.get("name", "N/A")
+        self.summary = self._parse_testsuite()
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+        return f"Validation Report for {self.name}"
+
+    def iter_testcases(self):
+        """Iterate over all testcase instances."""
+        for testcase in self.suite.findall("testcase"):
+            yield self._parse_testcase(testcase)
+
+    def _parse_testsuite(self):
+        summary = {
+            "errors": int(self.suite.get("errors", -1)),
+            "failures": int(self.suite.get("failures", -1)),
+            "skipped": int(self.suite.get("skipped", -1)),
+            "tests": int(self.suite.get("tests", -1)),
+            "time": float(self.suite.get("time", -1.)),  # [s]
+        }
+        return summary
+
+    def _parse_testcase(self, testcase):
+        data = {
+            "classname": self._parse_classname(testcase),
+            "name": testcase.get("name", "N/A"),
+            "time": float(testcase.get("time", -1.)),
+            "status": "passed",
+            "properties": {},
+            "message": "",  # available for skipped and failed tests and errors
+            "text": "",  # available for failed tests and errors
+        }
+
+        if (error := testcase.find("error")) is not None:
+            data["status"] = "error"
+            data["message"] = error.get("message")
+            data["text"] = error.text
+        elif (failure := testcase.find("failure")) is not None:
+            data["status"] = "failed"
+            data["message"] = failure.get("message")
+            data["text"] = failure.text
+        elif (skipped := testcase.find("skipped")) is not None:
+            status = skipped.get("type").removeprefix("pytest.")
+            status = status + "ped" if status == "skip" else status + "ed"
+            data["status"] = status
+            data["message"] = skipped.get("message")
+        # Note: xfail is a type of skip, Xpass looks identical to pass in xml
+
+        if props := testcase.find("properties"):
+            for prop in props.findall("property"):
+                data["properties"][prop.get("name")] = prop.get("value")
+
+        return data
+
+    def _parse_classname(self, testcase) -> str:
+        if (classname := testcase.get("classname")) is None:
+            return "N/A"
+        return classname.removeprefix(f"{self.name}.").removeprefix("tests.")
+
+
+class ValidationReportDirective(Directive):
+    required_arguments = 1  # path to xml
+
+    headers = {
+        "AO mode": None,
+        "IMG mode": None,
+        "Filter": None,
+        "Expected": "mag",
+        "Obtained": "mag",
+        "Difference": "mag",
+        "Status": None,
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.report = ValidationReport(self.arguments[0])
+
+    def run(self):
+        summary = nodes.paragraph(text=(
+            f"Showing results from {self.report.summary['tests']} "
+            f"tests for {self.report.name}"
+        ))
+
+        table = nodes.table()
+        tgroup = nodes.tgroup(cols=len(self.headers))
+        table += tgroup
+
+        for _ in self.headers:
+            tgroup += nodes.colspec(colwidth=1)
+
+        thead = nodes.thead()
+        tgroup += thead
+        header_row = nodes.row()
+        for header, unit in self.headers.items():
+            entry = nodes.entry()
+            entry += nodes.Text(header)
+            if unit is not None:
+                self._add_raw_html(entry, "<br>")
+                entry += nodes.Text(f"[{unit}]")
+            header_row += entry
+        thead += header_row
+
+        tbody = nodes.tbody()
+        tgroup += tbody
+        tbody.extend(list(self._collect_rows()))
+
+        footnote = nodes.paragraph(text=(
+            "Difference is calculated as obtained - expected, meaning a "
+            "positive difference indicates ScopeSim reached a fainter limiting "
+            "magnitude than the reference document, while a negative difference"
+            " means ScopeSim did not reach the reference magnitude in that "
+            "combination of modes and filter."
+        ))
+
+        return [summary, table, footnote]
+
+    def _collect_rows(self):
+        for testcase in self.report.iter_testcases():
+            row = nodes.row(classes=[f"pytest-{testcase['status']}"])
+            self._add_properties_to_row(row, testcase)
+
+            entry = nodes.entry()
+            if (url := testcase["properties"].get("link")) is not None:
+                row["classes"].append("clickable-row")
+                href_html = (
+                    "<a class=\"row-anchor\" "
+                    "target=\"_blank\" rel=\"noopener noreferrer\" "
+                    f"href=\"../../{url}\">{testcase['status']}</a>"
+                )
+                self._add_raw_html(entry, href_html)
+            else:
+                entry += nodes.Text(testcase["status"])
+            row += entry
+
+            yield row
+
+    def _add_properties_to_row(self, row, testcase) -> None:
+        if not testcase["properties"]:
+            return  # skip
+        self._add_cell_from_properties(row, testcase, "ao_mode")
+        self._add_cell_from_properties(row, testcase, "img_mode")
+        self._add_cell_from_properties(row, testcase, "filter")
+
+        entry = nodes.entry(classes=["nowrap"])
+        self._add_text_from_properties(entry, testcase, "expected")
+        self._add_raw_html(entry, " &plusmn; ")
+        self._add_text_from_properties(entry, testcase, "tolerance")
+        row += entry
+
+        self._add_cell_from_properties(row, testcase, "obtained")
+        self._add_cell_from_properties(row, testcase, "difference")
+
+    def _add_cell_from_properties(self, row, testcase, key: str) -> None:
+        entry = nodes.entry(classes=["nowrap"])
+        self._add_text_from_properties(entry, testcase, key)
+        row += entry
+
+    @staticmethod
+    def _add_text_from_properties(entry, testcase, key: str) -> None:
+        entry += nodes.Text(testcase["properties"].get(key, ""))
+
+    @staticmethod
+    def _add_raw_html(entry, html: str) -> None:
+        entry += nodes.raw("", html, format="html")
+
+
+def setup(app):
+    app.add_directive("validation-report", ValidationReportDirective)

--- a/docs/source/_static/clickable_rows.js
+++ b/docs/source/_static/clickable_rows.js
@@ -1,0 +1,13 @@
+document.addEventListener("DOMContentLoaded", function () {
+  document.querySelectorAll("tr.clickable-row").forEach(function(row) {
+    row.addEventListener("click", function(e) {
+      // Avoid double navigation if clicking directly on the link
+      if (e.target.closest("a")) return;
+
+      const link = this.querySelector("a[href]");
+      if (link) {
+        window.location = link.href;
+      }
+    });
+  });
+});

--- a/docs/source/_static/clickable_rows.js
+++ b/docs/source/_static/clickable_rows.js
@@ -1,12 +1,16 @@
 document.addEventListener("DOMContentLoaded", function () {
   document.querySelectorAll("tr.clickable-row").forEach(function(row) {
     row.addEventListener("click", function(e) {
-      // Avoid double navigation if clicking directly on the link
       if (e.target.closest("a")) return;
 
       const link = this.querySelector("a[href]");
-      if (link) {
-        window.location = link.href;
+      if (!link) return;
+
+      // Respect modifier keys
+      if (e.metaKey || e.ctrlKey) {
+        window.open(link.href, "_blank", "noopener");
+      } else {
+        link.click();
       }
     });
   });

--- a/docs/source/_static/validation_report.css
+++ b/docs/source/_static/validation_report.css
@@ -1,0 +1,41 @@
+/* Light row backgrounds */
+
+tr.pytest-passed {
+    background-color: #e8f5e9;   /* light green */
+}
+
+tr.pytest-failed {
+    background-color: #fdecea;   /* light red */
+}
+
+tr.pytest-xfailed {
+    background-color: #fff8e1;   /* light yellow */
+}
+
+tr.pytest-skipped {
+    background-color: #aaaaaa;   /* light gray */
+}
+
+
+
+/* Link on rows */
+
+.clickable-row {
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.clickable-row:hover {
+    background-color: #f0f4ff;
+}
+
+.clickable-row a {
+    color: inherit;
+    text-decoration: none;
+}
+
+/* Misc */
+
+.nowrap {
+    white-space: nowrap;
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -7,3 +7,4 @@ markers =
     slow: mark test as slow.
     badges: tests for the badge report
     irdb: tests for IRDB functionality (unrelated to a specific instrument package)
+    validation: tests for validating ScopeSim results (needed for docs)

--- a/requirements.readthedocs.txt
+++ b/requirements.readthedocs.txt
@@ -5,9 +5,12 @@ astropy
 
 docutils
 pyyaml
+pytest
 
 astar-utils
 scopesim
+scopesim_templates
+paramiko
 
 sphinx>=4.3.0
 sphinx-rtd-theme>=0.5.1


### PR DESCRIPTION
- Add a new pytest marker `validation` (see PR label).
- Refactor MICADO limiting magnitude test and add more mode combinations
- Update tolerances and xfail messages
- Configure RTD build to run pytest on (only) the validation tests (currently 1)
- Add a simple xml parser to read test results on RTD
- Add a custom Sphinx extension to render test results in table