### PR TITLE
Update of METIS FITS headers: INS.DRS.SLIT 

### DIFF
--- a/METIS/headers/FITS_lss_keywords.yaml
+++ b/METIS/headers/FITS_lss_keywords.yaml
@@ -29,3 +29,6 @@
             POS: [0, "IMG_N_PW position"]           # TODO
             POSNAME: ["!OBS.grism_opti12", "IMG_N_PW named position"]
             STAT: ["Standstill", "IMG_N_PW status"]
+
+          DRS:
+            SLIT: ["#slit_wheel.current_slit!", "Slit name"]


### PR DESCRIPTION
- Set `INS.DRS.SLIT` for lss mode, identical to `OPTI3.POSNAME`