### PR TITLE
Add PRNU effect definition to all METIS detector descriptions   

### DIFF
--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -69,6 +69,14 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
+  - name: prnu
+    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+    class: PixelResponseNonUniformity
+    include: True
+    kwargs:
+      prnu_std: 0.5         # 0.5% RMS — typical H2RG value
+      prnu_seed: 42
+
   - name: dark_current
     description: METIS LMS dark current
     class: DarkCurrent

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -17,7 +17,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  include_prnu: False      
+  include_pixel_response: False      
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain:
     1: 2.0            # electrons/ADU, email B.Serra 2024-10-09
@@ -70,12 +70,12 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: prnu
-    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+  - name: pixel_response
+    description: Pixel-to-pixel response non-uniformity 
     class: PixelResponseNonUniformity
-    include: "!DET.include_prnu"
+    include: "!DET.include_pixel_response"
     kwargs:
-      prnu_std: 0.005
+      prnu_std: 0.005 
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -74,7 +74,7 @@ effects:
     class: PixelResponseNonUniformity
     include: True
     kwargs:
-      prnu_std: 0.5         # 0.5% RMS — typical H2RG value
+      prnu_std: 0.005     
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -17,7 +17,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  include_pixel_response: False      
+  include_prnu: False      
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain:
     1: 2.0            # electrons/ADU, email B.Serra 2024-10-09
@@ -70,10 +70,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: pixel_response
+  - name: prnu
     description: Pixel-to-pixel response non-uniformity 
     class: PixelResponseNonUniformity
-    include: "!DET.include_pixel_response"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.005 
       prnu_seed: 42

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -17,7 +17,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
+  include_prnu: False      
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain:
     1: 2.0            # electrons/ADU, email B.Serra 2024-10-09
@@ -73,7 +73,7 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: "!DET.prnu_include"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.005
       prnu_seed: 42

--- a/METIS/METIS_DET_IFU.yaml
+++ b/METIS/METIS_DET_IFU.yaml
@@ -17,6 +17,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
+  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain:
     1: 2.0            # electrons/ADU, email B.Serra 2024-10-09
@@ -72,9 +73,9 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: True
+    include: "!DET.prnu_include"
     kwargs:
-      prnu_std: 0.005     
+      prnu_std: 0.005
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -15,8 +15,7 @@ properties:
   temperature: -233
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  include_prnu: False       
+  mindit: 1.3               # seconds, Roy van Boekel, pers. communication    
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain: 2
   dark_current: 0.1         # [e-/s]
@@ -51,14 +50,6 @@ effects:
   - name: exposure_action
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
-
-  - name: prnu
-    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
-    class: PixelResponseNonUniformity
-    include: "!DET.include_prnu"
-    kwargs:
-      prnu_std: 0.005
-      prnu_seed: 42
 
   - name: dark_current
     description: METIS LMS dark current

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -51,6 +51,14 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
+  - name: prnu
+    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+    class: PixelResponseNonUniformity
+    include: True
+    kwargs:
+      prnu_std: 0.5        # 0.5% RMS — typical H2RG value
+      prnu_seed: 42
+
   - name: dark_current
     description: METIS LMS dark current
     class: DarkCurrent

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -16,7 +16,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
-  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
+  include_prnu: False       
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain: 2
   dark_current: 0.1         # [e-/s]
@@ -55,7 +55,7 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: "!DET.prnu_include"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.005
       prnu_seed: 42

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -56,7 +56,7 @@ effects:
     class: PixelResponseNonUniformity
     include: True
     kwargs:
-      prnu_std: 0.5        # 0.5% RMS — typical H2RG value
+      prnu_std: 0.005        
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IFU_SMPL.yaml
+++ b/METIS/METIS_DET_IFU_SMPL.yaml
@@ -16,6 +16,7 @@ properties:
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
   mindit: 1.3               # seconds, Roy van Boekel, pers. communication
+  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
   full_well: 1.e+5   # electrons, E-TNT-MPIA-1004, v1-0
   gain: 2
   dark_current: 0.1         # [e-/s]
@@ -54,9 +55,9 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: True
+    include: "!DET.prnu_include"
     kwargs:
-      prnu_std: 0.005        
+      prnu_std: 0.005
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -19,6 +19,7 @@ properties:
   temperature: -230
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
+  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
   layout:
     file_name: "FPA_metis_img_lm_layout.dat"
   qe_curve:
@@ -85,9 +86,9 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: True
+    include: "!DET.prnu_include"
     kwargs:
-      prnu_std: 0.005         
+      prnu_std: 0.005
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -87,7 +87,7 @@ effects:
     class: PixelResponseNonUniformity
     include: True
     kwargs:
-      prnu_std: 0.5         # 0.5% RMS — typical H2RG value
+      prnu_std: 0.005         
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -19,7 +19,7 @@ properties:
   temperature: -230
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
+  include_prnu: False     
   layout:
     file_name: "FPA_metis_img_lm_layout.dat"
   qe_curve:
@@ -86,7 +86,7 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: "!DET.prnu_include"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.005
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -19,7 +19,7 @@ properties:
   temperature: -230
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_pixel_response: False     
+  include_prnu: False     
   layout:
     file_name: "FPA_metis_img_lm_layout.dat"
   qe_curve:
@@ -83,10 +83,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: pixel_response
+  - name: prnu
     description: Pixel-to-pixel response non-uniformity
     class: PixelResponseNonUniformity
-    include: "!DET.include_pixel_response"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.005
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -19,7 +19,7 @@ properties:
   temperature: -230
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_prnu: False     
+  include_pixel_response: False     
   layout:
     file_name: "FPA_metis_img_lm_layout.dat"
   qe_curve:
@@ -83,10 +83,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: prnu
-    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+  - name: pixel_response
+    description: Pixel-to-pixel response non-uniformity
     class: PixelResponseNonUniformity
-    include: "!DET.include_prnu"
+    include: "!DET.include_pixel_response"
     kwargs:
       prnu_std: 0.005
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_LM.yaml
+++ b/METIS/METIS_DET_IMG_LM.yaml
@@ -82,6 +82,14 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
+  - name: prnu
+    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+    class: PixelResponseNonUniformity
+    include: True
+    kwargs:
+      prnu_std: 0.5         # 0.5% RMS — typical H2RG value
+      prnu_seed: 42
+
   - name: dark_current
     description: METIS LM dark current
     class: DarkCurrent

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -69,6 +69,14 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
+  - name: prnu
+    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+    class: PixelResponseNonUniformity
+    include: True
+    kwargs:
+      prnu_std: 0.010         
+      prnu_seed: 42
+
   - name: dark_current
     description: METIS Aquarius dark current
     class: DarkCurrent

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -16,6 +16,7 @@ properties:
   temperature: -265
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
+  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
   mindit: 0.008            # seconds, E-REP-NOVA-MET-1191, v2-0
   full_well: 1.e+6  # electrons, low-capacity mode
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
@@ -72,9 +73,9 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: True
+    include: "!DET.prnu_include"
     kwargs:
-      prnu_std: 0.001         
+      prnu_std: 0.001
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -74,7 +74,7 @@ effects:
     class: PixelResponseNonUniformity
     include: True
     kwargs:
-      prnu_std: 0.010         
+      prnu_std: 0.001         
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -16,7 +16,7 @@ properties:
   temperature: -265
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
+  include_prnu: False      
   mindit: 0.008            # seconds, E-REP-NOVA-MET-1191, v2-0
   full_well: 1.e+6  # electrons, low-capacity mode
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
@@ -73,7 +73,7 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: "!DET.prnu_include"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -16,7 +16,7 @@ properties:
   temperature: -265
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_pixel_response: False      
+  include_prnu: False      
   mindit: 0.008            # seconds, E-REP-NOVA-MET-1191, v2-0
   full_well: 1.e+6  # electrons, low-capacity mode
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
@@ -70,10 +70,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: pixel_response
+  - name: prnu
     description: Pixel-to-pixel response non-uniformity 
     class: PixelResponseNonUniformity
-    include: "!DET.include_pixel_response"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_N_Aquarius.yaml
+++ b/METIS/METIS_DET_IMG_N_Aquarius.yaml
@@ -16,7 +16,7 @@ properties:
   temperature: -265
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_prnu: False      
+  include_pixel_response: False      
   mindit: 0.008            # seconds, E-REP-NOVA-MET-1191, v2-0
   full_well: 1.e+6  # electrons, low-capacity mode
   dark_current: 13         # [e-/s] E-REP-NOVA-MET-1191, v2-0
@@ -70,10 +70,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: prnu
-    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+  - name: pixel_response
+    description: Pixel-to-pixel response non-uniformity 
     class: PixelResponseNonUniformity
-    include: "!DET.include_prnu"
+    include: "!DET.include_pixel_response"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -91,7 +91,7 @@ effects:
     class: PixelResponseNonUniformity
     include: True
     kwargs:
-      prnu_std: 0.010         # 1.0% RMS — GeoSnap estimate
+      prnu_std: 0.001        
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -21,6 +21,7 @@ properties:
   temperature: -240
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
+  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
   border: [28, 28, 28, 28]
   layout:
     file_name: "FPA_metis_img_n_geosnap_layout.dat"
@@ -89,9 +90,9 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: True
+    include: "!DET.prnu_include"
     kwargs:
-      prnu_std: 0.001        
+      prnu_std: 0.001
       prnu_seed: 42
 
   - name: dark_current

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -21,7 +21,7 @@ properties:
   temperature: -240
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  prnu_include: False       # off by default; enabled per mode via OBS.prnu_include
+  include_prnu: False      
   border: [28, 28, 28, 28]
   layout:
     file_name: "FPA_metis_img_n_geosnap_layout.dat"
@@ -90,7 +90,7 @@ effects:
   - name: prnu
     description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
     class: PixelResponseNonUniformity
-    include: "!DET.prnu_include"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -21,7 +21,7 @@ properties:
   temperature: -240
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_pixel_response: False      
+  include_prnu: False      
   border: [28, 28, 28, 28]
   layout:
     file_name: "FPA_metis_img_n_geosnap_layout.dat"
@@ -87,10 +87,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: pixel_response
+  - name: prnu
     description: Pixel-to-pixel response non-uniformity
     class: PixelResponseNonUniformity
-    include: "!DET.include_pixel_response"
+    include: "!DET.include_prnu"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -86,6 +86,14 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
+  - name: prnu
+    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+    class: PixelResponseNonUniformity
+    include: True
+    kwargs:
+      prnu_std: 0.010         # 1.0% RMS — GeoSnap estimate
+      prnu_seed: 42
+
   - name: dark_current
     description: METIS GeoSnap dark current
     class: DarkCurrent

--- a/METIS/METIS_DET_IMG_N_GeoSnap.yaml
+++ b/METIS/METIS_DET_IMG_N_GeoSnap.yaml
@@ -21,7 +21,7 @@ properties:
   temperature: -240
   dit: "!OBS.dit"
   ndit: "!OBS.ndit"
-  include_prnu: False      
+  include_pixel_response: False      
   border: [28, 28, 28, 28]
   layout:
     file_name: "FPA_metis_img_n_geosnap_layout.dat"
@@ -87,10 +87,10 @@ effects:
     description: Summing up sky signal for all DITs and NDITs
     class: ExposureIntegration
 
-  - name: prnu
-    description: Pixel-to-pixel response non-uniformity — fixed multiplicative gain map
+  - name: pixel_response
+    description: Pixel-to-pixel response non-uniformity
     class: PixelResponseNonUniformity
-    include: "!DET.include_prnu"
+    include: "!DET.include_pixel_response"
     kwargs:
       prnu_std: 0.001
       prnu_seed: 42


### PR DESCRIPTION
- Added the description of the PRNU variation in the METIS detector YAMLS  (IFU, IFU_SMPL, IMG_LM, Aquarius, GeoSnap)
- H2RG detectors (IFU, IFU_SMPL, IMG_LM): `prnu_std = 0.005` 
- Aquarius and GeoSnap: `prnu_std = 0.001` 
- Fixed seed (`42`) used instead of `SIM.random.seed`

Closes #325 