### PR TITLE
[METIS] Extend wavelength range below 2.7um

### DIFF
--- a/METIS/TER_lms_predisperser_prism.dat
+++ b/METIS/TER_lms_predisperser_prism.dat
@@ -1,7 +1,7 @@
 # author : Oliver Czoske
 # source : E-SPE-NOVA-MET-1049_4-0 (METIS transmission budget)
 # date_created : 2020-04-13
-# date_modified : 2022-05-11
+# date_modified : 2026-03-31
 # status : version 4.0
 # type : prism:transmission
 # wavelength_unit : um
@@ -9,8 +9,19 @@
 # comment : extracted from excel sheet "CFO+LMS"
 # changes :
 #  - 2022-05-11 (OC) updated to 4.0
+#  - 2026-03-31 (OC) extend below 2.7um for order 41
 #
 wavelength	transmission	reflection	emissivity
+2.60	0.867	0.133	0
+2.61	0.867	0.133	0
+2.62	0.867	0.133	0
+2.63	0.867	0.133	0
+2.64	0.867	0.133	0
+2.65	0.867	0.133	0
+2.66	0.867	0.133	0
+2.67	0.867	0.133	0
+2.68	0.867	0.133	0
+2.69	0.867	0.133	0
 2.70	0.867	0.133	0
 2.71	0.867	0.133	0
 2.72	0.867	0.133	0

--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -22,6 +22,7 @@ changes:
   - 2025-08-26 (OC) modes for Leiden sky observations
   - 2025-09-29 (OC) version bump
   - 2025-10-09 (OC) proper MJD value
+  - 2026-03-31 (OC) set wave_min to 2.65um for bluest LMS settings
 
 packages:
   - Armazones
@@ -534,7 +535,7 @@ properties:
     seed: None                         # 9001
 
   spectral:
-    wave_min: 2.85
+    wave_min: 2.65
     wave_mid: 8.425
     wave_max: 14.0
 


### PR DESCRIPTION
It was found that simulations in LMS order 41 (2.6574-2.6972um) did not produce any throughput. The reason was that `TER_lms_predisperser_prism.dat` only went to 2.7um and was extrapolated using 0 transmission. This PR extends the file to 2.6 um with constant transmission.

Turns out this wasn't the severest problem. `!SIM.spectral.wave_min` was set to 2.85um, which precluded the bluest LMS settings. Changed to 2.65um.