### PR TITLE
Fibre transmission for WCU lasers

### DIFF
--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -23,3 +23,4 @@ diam_is_out: 100        # [mm] diameter if integrating sphere output port
 rho_is:        0.95     # [] reflectivity of integrating sphere
 rho_tube:      0.95     # [] reflectivity of tube between BB and IS
 emiss_mask:    1.00     # [] emissivity of focal-plane mask
+fibre_transmission: 0.1 # [] transmission of fibres injecting laser into IS


### PR DESCRIPTION
Add parameter `fibre_transmission` in `metis_wcu_config.yaml`, default is 0.1.

Needs https://github.com/AstarVienna/ScopeSim/pull/904