### PR TITLE
Add illumination effect inclusion

### DIFF
--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -99,8 +99,7 @@ effects:
     description: Large-scale illumination variation across the image plane
     class: Illumination
     include: "!INST.include_illumination"
-
-
+    
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -18,6 +18,7 @@ properties:
   pixel_scale: 0.00547         # arcsec / pixel, METIS_1097
   plate_scale: 0.30389         # arcsec / mm
   filter_file_format: "filters/TC_filter_{}.dat"
+  include_illumination: False     
 
 effects:
   - name: img_lm_optics
@@ -93,6 +94,12 @@ effects:
     include: True
     kwargs:
       filename: headers/FITS_img_lm_keywords.yaml
+
+  - name: illumination
+    description: Large-scale illumination variation across the image plane
+    class: Illumination
+    include: "!INST.include_illumination"
+
 
 ---
 ### default simulation parameters needed for a METIS simulation

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -92,9 +92,7 @@ effects:
     description: Large-scale illumination variation across the image plane
     class: Illumination
     include: "!INST.include_illumination"
-
-
-
+    
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -16,6 +16,7 @@ properties:
   pixel_scale: 0.00679         # arcsec / pixel, METIS-1097
   plate_scale: 0.377222222222  # arcsec / mm
   filter_file_format: "filters/TC_filter_{}.dat"
+  include_illumination: False
 
 effects:
   - name: img_n_optics
@@ -86,6 +87,12 @@ effects:
     include: True
     kwargs:
       filename: headers/FITS_img_n_keywords.yaml
+  
+  - name: illumination
+    description: Large-scale illumination variation across the image plane
+    class: Illumination
+    include: "!INST.include_illumination"
+
 
 
 ---


### PR DESCRIPTION
- Include the Illumination effect as `"!INST."` , default is set to `FALSE`

- name: illumination
description: Large-scale illumination variation across the image plane
class: Illumination
include: "!INST.include_illumination"