### PR TITLE
Bump `needs_scopesim` in preparation of release

### DIFF
--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -6,7 +6,7 @@ alias: OBS
 name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
 status: development
-needs_scopesim: "v0.11.1a1"
+needs_scopesim: "v0.11.3"
 date_modified: 2025-10-09
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular

--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -6,7 +6,7 @@ alias: OBS
 name: MICADO_default_configuration
 description: default parameters needed for a MICADO simulation
 status: development
-needs_scopesim: "v0.11.0"
+needs_scopesim: "v0.11.3"
 date_modified: 2025-10-09
 changes:
   - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits

--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -6,7 +6,7 @@ alias: OBS
 name: MICADO_default_configuration
 description: default parameters needed for a MICADO simulation
 status: development
-needs_scopesim: "v0.10.0b4"
+needs_scopesim: "v0.11.0"
 date_modified: 2025-10-09
 changes:
   - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits


### PR DESCRIPTION
MICADO needs 0.11.3 because of offset slits (only spec mode but reasonable to bump top-level as well for release).
METIS needs 0.11.3 because new effects.