### PR TITLE
Blocking filter for MICADO

### DIFF
--- a/MICADO/MICADO.yaml
+++ b/MICADO/MICADO.yaml
@@ -91,7 +91,7 @@ effects:
             - xY1
         filename_format: "!INST.filter_file_format"
         current_filter: "!OBS.filter_name_fw2"
-        minimum_throughput: 1.01e-4
+        minimum_throughput: 1.01e-33
         outer: 0.2
         outer_unit: "m"
 

--- a/MICADO/filters/TC_filter_block.dat
+++ b/MICADO/filters/TC_filter_block.dat
@@ -1,9 +1,14 @@
 # author : Kieran Leschinski
 # source : Ric Davies
 # date_created : 2022-03-17
-# date_modified : 2022-03-17
+# date_modified : 2026-05-03
 # status : FDR list of filters
+# wavelength_unit: um
+# changes:
+# - 2026-05-03 (OC) change level to 1e-32
 #
 wavelength  transmission
-0.3         0
+0.3         0.0
+0.35        1.e-32
+2.95        1.e-32
 3.0         0


### PR DESCRIPTION
The blocking filter in `filter_wheel_2` in MICADO had a throughput of 0. As we know from METIS, there needs to be a finite throughput window so that the minimum and maximum wavelengths of a wave band can be determined. As for METIS, the MICADO blocking filter now has a throughput of 1e-32 over a wide wavelength range. 
To enable that, `minimum_throughput` in the effect definition had to be lowered below that level. Not sure anymore what that parameter was needed for, the scopesim code (in `ter_curve.FilterCurve`) seems rather hacky. In METIS it is set to 0.

Closes https://github.com/AstarVienna/ScopeSim/issues/917