### PR TITLE
Inter-pixel capacitance for MICADO

### DIFF
--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -14,6 +14,7 @@ properties:
     x: 0
     y: 0
     gain: 1  # should be taken from FPA layout??
+    include_ipc: false     # inter-pixel capacitance
 
 effects:
   - name: full_detector_array
@@ -70,6 +71,15 @@ effects:
     include: False
     kwargs:
       border: [0, 0, 0, 0]
+
+  - name: ipc
+    description: Inter-pixel capacitance
+    class: InterPixelCapacitance
+    include: "!DET.include_ipc"
+    kwargs:   # values from Kannawadi+2016 (H4RG!)
+      alpha_edge:   0.02
+      alpha_corner: 0.002
+      alpha_aniso:  0.
 
   - name: readout_noise
     description: Readout noise frames


### PR DESCRIPTION
This PR includes the `InterPixelCapacitance` effect in `MICADO_H4RG.yaml`. The parametrisation and parameter values are taken from  [Kannawadi et al., PASP 128, 095001 (2016)](https://iopscience.iop.org/article/10.1088/1538-3873/128/967/095001/pdf) and are currently identical to those used in METIS (cf. #272). They should be updated when measurements become available.

By default, the effect is not included. To include set `opttrain['ipc'].include` or `!DET.include_ipc` to `True`.

Example:
```
cmd = sim.UserCommands(use_instrument="MICADO", set_modes=["SCAO", "IMG_4mas"])
mcd = sim.OpticalTrain(cmd)
mcd['filter_wheel_2'].change_filter('block')   # observe dark
mcd.observe()
# without ipc
hdul = mcd.readout(dit=100, ndit=1)[0]
np.mean(hdul[1].data)     # 4199.027
np.std(hdul[1].data)         # 63.902557
# with ipc
mcd['ipc'].include = True
hdul = mcd.readout(dit=100, ndit=1)[0]
np.mean(hdul[1].data)     # 4199.8267      (identical mean)
np.std(hdul[1].data)         # 59.013878       (reduced noise)
```

Closes #346