### PR TITLE
ExtraFitsKeywords for MICADO

### DIFF
--- a/MICADO/MICADO.yaml
+++ b/MICADO/MICADO.yaml
@@ -115,3 +115,10 @@ effects:
         minimum_throughput: 1.01e-4
         outer: 0.2
         outer_unit: "m"
+
+- name: mcd_fits_keywords
+    description: FITS keywords specific to MICADO
+    class: ExtraFitsKeywords
+    include: True
+    kwargs:
+      filename: headers/FITS_mcd_keywords.yaml

--- a/MICADO/MICADO_H4RG.yaml
+++ b/MICADO/MICADO_H4RG.yaml
@@ -117,9 +117,9 @@ effects:
 #    class: SimulationConfigFitsKeywords
 #    include: True
 
-  - name: extra_fits_keywords
-    decription: adds extra FITS keywords from a yaml file
+  - name: detector_fits_keywords
+    decription: FITS keywords specific to the detectors
     class: ExtraFitsKeywords
     include: True
     kwargs:
-      filename: FITS_extra_keywords.yaml
+      filename: headers/FITS_H4RG_keywords.yaml

--- a/MICADO/MICADO_SPEC.yaml
+++ b/MICADO/MICADO_SPEC.yaml
@@ -25,6 +25,12 @@ effects :
     s_colname : "xi"
     col_number_start : 1
 
+- name: spec_fits_keywords
+  description: FITS keywords specific to spectroscopy
+  class: ExtraFitsKeywords
+  include: True
+  kwargs:
+    filename: headers/FITS_spec_keywords.yaml
 
 ---
 ### default simulation parameters needed for a MICADO SPEC simulation

--- a/MICADO/headers/FITS_H4RG_keywords.yaml
+++ b/MICADO/headers/FITS_H4RG_keywords.yaml
@@ -1,0 +1,18 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        DET:
+          DIT:     ["!OBS.dit", "[s]"]
+          NDIT:    "!OBS.ndit"
+          NEXP:    1
+          READOUT: CDS
+          SUBARRY: FULL
+
+- ext_type: ImageHDU
+  keywords:
+    EXTNAME:       "DET§.IMG"
+    BUNIT:         "ADU"
+    HIERARCH:
+      ESO:
+        DET:

--- a/MICADO/headers/FITS_mcd_keywords.yaml
+++ b/MICADO/headers/FITS_mcd_keywords.yaml
@@ -1,0 +1,12 @@
+- ext_type: PrimaryHDU
+  keywords:
+    INSTRUME: MICADO
+
+    HIERARCH:
+      ESO:
+        INS:
+          SLIT:
+            NAME: ["#slit_wheel.current_slit!", "Selected slit"]
+          FILT:
+            NAME: ["#filter_wheel_1.current_filter!", "Selected filter"]
+            # Needs to be one of fw1 or fw2

--- a/MICADO/headers/FITS_spec_keywords.yaml
+++ b/MICADO/headers/FITS_spec_keywords.yaml
@@ -1,0 +1,7 @@
+- ext_type: PrimaryHDU
+  keywords:
+    HIERARCH:
+      ESO:
+        INS:
+          MODE:
+            NAME:  SPE


### PR DESCRIPTION
An attempt to use `ExtraFitsKeywords` for MICADO. The goal is to align the MICADO headers with the pipeline needs.

Issues:
- `INST.FILT.NAME` should be taken from one of the two filter wheels. The necessary logic may be impossible to implement in yaml alone.


Closes #240 