### PR TITLE
Add missing TECH keywords to most modes

### DIFF
--- a/METIS/default.yaml
+++ b/METIS/default.yaml
@@ -7,7 +7,7 @@ name: METIS_default_configuration
 description: default parameters needed for a METIS simulation
 status: development
 needs_scopesim: "v0.11.3"
-date_modified: 2025-10-09
+date_modified: 2026-05-29
 changes:
   - 2021-12-16 (OC) chopnod defaults to perpendicular
   - 2021-12-16 (OC) default slits renamed
@@ -23,6 +23,7 @@ changes:
   - 2025-09-29 (OC) version bump
   - 2025-10-09 (OC) proper MJD value
   - 2026-03-31 (OC) set wave_min to 2.65um for bluest LMS settings
+  - 2026-05-29 (FH) added tech keyword to most modes
 
 packages:
   - Armazones
@@ -53,7 +54,6 @@ properties:
   #       corresponding yaml file with the keywords.
   tplname: "METIS_img_lm_obs_GenericOffset"
   catg: "SCIENCE"
-  tech: "IMAGE,LM"
   type: "OBJECT"
   # More default properties for the observation
   mjdobs: "61529.104"
@@ -82,6 +82,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: IMG_LM        # use as FITS header keyword
+      tech: IMAGE,LM
       psf_file: PSF_SCAO_9mag_06seeing.fits
       filter_name: Lp
       nd_filter_name: open
@@ -102,6 +103,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       ins_mode: IMG_N         # use as FITS header keyword
+      tech: IMAGE,N
       psf_file: PSF_SCAO_9mag_06seeing.fits
       filter_name: N2
       nd_filter_name: open
@@ -125,6 +127,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: LSS_L         # use as FITS header keyword
+      tech: LSS,LM
       psf_file: PSF_LM_9mag_06seeing.fits
       trace_file: TRACE_LSS_L.fits
       efficiency_file: TER_grating_L.fits
@@ -150,6 +153,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: IMG_M         # use as FITS header keyword
+      tech: LSS,LM
       psf_file: PSF_LM_9mag_06seeing.fits
       trace_file: TRACE_LSS_M.fits
       efficiency_file: TER_grating_M.fits
@@ -175,6 +179,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       ins_mode: IMG_N         # use as FITS header keyword
+      tech: LSS,N
       psf_file: PSF_N_9mag_06seeing.fits
       trace_file: TRACE_LSS_N.fits
       efficiency_file: TER_grating_N.fits
@@ -201,6 +206,7 @@ mode_yamls:
       - METIS_DET_IFU.yaml
     properties:
       ins_mode: LMS          # use as FITS header keyword
+      tech: IFU
       psf_file: PSF_LM_9mag_06seeing.fits
       slit: false
       adc: false
@@ -212,7 +218,7 @@ mode_yamls:
     alias: OBS
     name: lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode"
-    status: experimental
+    status: concept
     yamls:
       - Armazones.yaml
       - ELT.yaml
@@ -238,6 +244,7 @@ mode_yamls:
       - METIS_DET_IFU_SMPL.yaml
     properties:
       ins_mode: LMS_cube          # use as FITS header keyword
+      tech: IFU
       psf_file: PSF_LM_9mag_06seeing.fits
       interp_psf: False
       slit: false
@@ -259,6 +266,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: IMG_LM        # use as FITS header keyword
+      tech: IMAGE,LM
       pupil_mask: PPS-LM
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -280,6 +288,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       ins_mode: IMG_N          # use as FITS header keyword
+      tech: IMAGE,N
       pupil_mask: PPS-N
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -304,6 +313,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: LSS_L        # use as FITS header keyword
+      tech: LSS,LM
       pupil_mask: PPS-CFO2
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -330,6 +340,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: LSS_M        # use as FITS header keyword
+      tech: LSS,LM
       pupil_mask: PPS-CFO2
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -356,6 +367,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       ins_mode: LSS_N        # use as FITS header keyword
+      tech: LSS,N
       pupil_mask: PPS-CFO2
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -383,6 +395,7 @@ mode_yamls:
       - METIS_DET_IFU.yaml
     properties:
       ins_mode: LMS          # use as FITS header keyword
+      tech: IFU
       pupil_mask: PPS-LMS
       psf_file: none
       psf_name: "!OBS.pupil_mask"
@@ -396,7 +409,7 @@ mode_yamls:
     alias: OBS
     name: wcu_lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode with WCU"
-    status: experimental
+    status: concept
     yamls:
       - METIS_WCU.yaml
       - METIS.yaml
@@ -427,6 +440,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: LSS_L        # use as FITS header keyword
+      tech: LSS,LM
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_L.fits
       efficiency_file: TER_grating_L.fits
@@ -451,6 +465,7 @@ mode_yamls:
       - METIS_DET_IMG_LM.yaml
     properties:
       ins_mode: LSS_M        # use as FITS header keyword
+      tech: LSS,LM
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_M.fits
       efficiency_file: TER_grating_M.fits
@@ -475,6 +490,7 @@ mode_yamls:
       - METIS_DET_IMG_N_GeoSnap.yaml
     properties:
       ins_mode: LSS_N        # use as FITS header keyword
+      tech: LSS,N
       psf_file: PSF_N_9mag_06seeing.fits    # REPLACE!
       trace_file: TRACE_LSS_N.fits
       efficiency_file: TER_grating_N.fits
@@ -500,6 +516,7 @@ mode_yamls:
       - METIS_DET_IFU.yaml
     properties:
       ins_mode: LMS          # use as FITS header keyword
+      tech: IFU
       psf_file: PSF_LM_9mag_06seeing.fits    # REPLACE!
       slit: false
       adc: false
@@ -511,7 +528,7 @@ mode_yamls:
     alias: OBS
     name: leiden_lms_extended
     description: "METIS LM-band integral-field spectroscopy, extended mode with Leiden sky"
-    status: experimental
+    status: concept
     yamls:
       - Leiden_sky.yaml
       - METIS.yaml

--- a/METIS/headers/FITS_img_lm_keywords.yaml
+++ b/METIS/headers/FITS_img_lm_keywords.yaml
@@ -4,7 +4,7 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "IMAGE,LM"
+          TECH: "!OBS.tech"  # duplicate from FITS_common_keywords.yaml
         INS:
           OPTI4:                # LMS beamsplitter pickoff wheel
             DEVSIM: [true, "Device simulation flag"]

--- a/METIS/headers/FITS_img_n_keywords.yaml
+++ b/METIS/headers/FITS_img_n_keywords.yaml
@@ -4,7 +4,7 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "IMAGE,N"
+          TECH: "!OBS.tech"  # duplicate from FITS_common_keywords.yaml
         INS:
 
           OPTI4:                # LMS beamsplitter pickoff wheel

--- a/METIS/headers/FITS_lms_keywords.yaml
+++ b/METIS/headers/FITS_lms_keywords.yaml
@@ -4,7 +4,7 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "IFU"
+          TECH: "!OBS.tech"  # duplicate from FITS_common_keywords.yaml
         INS:
           LMS:                  # LMS mode (Nominal or Extended)
             MODE: "Nominal"

--- a/METIS/headers/FITS_lss_keywords.yaml
+++ b/METIS/headers/FITS_lss_keywords.yaml
@@ -4,7 +4,7 @@
     HIERARCH:
       ESO:
         DPR:
-          TECH:   "LSS"         # TODO: How to add the filter name?
+          TECH: "!OBS.tech"  # duplicate from FITS_common_keywords.yaml
         INS:
           OPTI4:                # LMS beamsplitter pickoff wheel
             DEVSIM: [true, "Device simulation flag"]

--- a/MICADO/default.yaml
+++ b/MICADO/default.yaml
@@ -7,7 +7,7 @@ name: MICADO_default_configuration
 description: default parameters needed for a MICADO simulation
 status: development
 needs_scopesim: "v0.11.3"
-date_modified: 2025-10-09
+date_modified: 2026-05-29
 changes:
   - 2023-07-13 (OC) add modes for FDR slits, deprecate pre-FDR slits
   - 2025-06-27 (FH) add needs_scopesim keyword
@@ -15,6 +15,7 @@ changes:
   - 2025-10-17 (JB) add parametes for FITS keywords, tplstart as MJD
   - 2026-01-02 (OC) random seed to None
   - 2026-04-09 (OC) new SPEC mode, rename slits
+  - 2026-05-29 (FH) added tech keyword to most modes
 
 packages:
 - Armazones
@@ -39,7 +40,6 @@ properties :
   dit : 60
   ndit : 1
   catg : SCIENCE
-  tech : IMAGE
   type : OBJECT
   # Should be datetimes, but is copied verbatim, so should work.
   mjdobs : 61529.104
@@ -85,6 +85,7 @@ mode_yamls :
     filter_name_fw1: open
     filter_name_fw2: Ks
     filter_name_pupil: open
+    tech: IMAGE
     fits_ins_filt: Ks
 
 - object : observation
@@ -98,6 +99,7 @@ mode_yamls :
     filter_name_fw1: open
     filter_name_fw2: Ks
     filter_name_pupil: open
+    tech: IMAGE
     fits_ins_filt: Ks
 
 - object : observation
@@ -139,6 +141,7 @@ mode_yamls :
     filter_name_fw1 : Spec_HK
     filter_name_fw2 : open
     filter_name_pupil : open
+    tech: SPEC
     fits_ins_filt : Spec_HK
 
 - object : observation
@@ -155,6 +158,7 @@ mode_yamls :
     filter_name_fw1 : Spec_HK
     filter_name_fw2 : open
     filter_name_pupil : open
+    tech: SPEC
     fits_ins_filt : Spec_HK
 
 - object : observation
@@ -171,6 +175,7 @@ mode_yamls :
     filter_name_fw1 : Spec_IJ
     filter_name_fw2 : open
     filter_name_pupil : open
+    tech: SPEC
     fits_ins_filt : Spec_IJ
 
 ---


### PR DESCRIPTION
Using best-guess values for MICADO, for METIS taken from: https://github.com/AstarVienna/irdb/issues/356#issuecomment-4553690985

Closes #356, except the LMS extended mode, which is not yet implemented anyway (also set the status to concept for that).

Not sure if some of the duplication mentioned in the comments is necessary. Probably not, but don't have time to check.
Also added keywords to the deprecated individual MICADO SPEC modes, doesn't hurt.