### PR TITLE
Demo notebook for SkycalcTERCurve

### DIFF
--- a/METIS/docs/example_notebooks/demos/demo_skycalc.ipynb
+++ b/METIS/docs/example_notebooks/demos/demo_skycalc.ipynb
@@ -1,0 +1,266 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "54686e5f-f108-4633-bf8d-d13205e07f92",
+   "metadata": {},
+   "source": [
+    "# The `SkycalcTERCurve` effect in ScopeSim\n",
+    "\n",
+    "This notebook demonstrates how to work with the skycalc effect, `SkycalcTERCurve`. This effect provides the atmospheric emission and transmission that are applied to a source object in ScopeSim. The effect is based on `skycalc_ipy`, a python wrapper to ESO’s SkyCalc tool."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c01ec5f-9e28-41f2-b047-8e4aef3e1b88",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "from astropy import units as u"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c64d3cf-75f7-4174-b1c7-6bb202b58fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scopesim as sim\n",
+    "\n",
+    "# If you have not done so already, please download the relevant instrument packages by uncommenting the following line:\n",
+    "# sim.download_packages([\"Armazones\", \"ELT\", \"METIS\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "431dfc2a-a822-43fc-8bdb-f7762b8b6583",
+   "metadata": {},
+   "source": [
+    "We use the `SkycalcTERCurve` in the context of METIS/LMS, although sky mode of any other instrument would do as well. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27271168-1d50-4fa2-8970-ae5caca56a87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = sim.UserCommands(use_instrument=\"METIS\", set_modes=[\"lms\"])\n",
+    "cmd[\"!OBS.wavelen\"] = 3.5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f28719-eeb7-41f9-8ee7-d748d39ea5dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metis = sim.OpticalTrain(cmd)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04d263d1-306a-4a5a-8625-34471fea65d8",
+   "metadata": {},
+   "source": [
+    "The METIS optical train includes the `SkycalcTERCurve` effect under the name `skycalc_atmosphere`. We assign it to a variable for convenience."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d65b08f-5384-456e-b6da-696eb2c8740a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky = metis['skycalc_atmosphere']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "991e9b1c-00e5-4622-a813-542c90887664",
+   "metadata": {},
+   "source": [
+    "## Inspecting and modifying sky parameters\n",
+    "\n",
+    "The list of parameters that are sent to the ESO skycalc server when requesting a sky spectrum can be obtained by simply printing the effect object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8d3eac4-af5d-4cfc-aa15-20476fbb3ccf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(sky)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9136d40-f4ae-420c-bb48-3f12ab8215b7",
+   "metadata": {},
+   "source": [
+    "The emission and transmission spectra are returned as columns in `sky.skycalc_table` and can be plotted as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85df87ea-d8a4-4bf9-8638-bec13981a99c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl = sky.skycalc_table\n",
+    "\n",
+    "# Extract columns and restrict to a smaller wavelength range\n",
+    "wavelength = tbl['wavelength'].to(u.um)\n",
+    "idx = (wavelength > 3.4*u.um) * (wavelength < 3.6*u.um)\n",
+    "transmission = tbl['transmission']\n",
+    "emission = tbl['emission']\n",
+    "\n",
+    "_, axes = plt.subplots(2, 1, figsize=(8, 8), sharex=True)\n",
+    "axes[0].plot(wavelength[idx], transmission[idx])\n",
+    "axes[0].set_ylabel(\"Transmission\")\n",
+    "axes[0].set_xlim(3.4, 3.6)\n",
+    "axes[1].plot(wavelength[idx], emission[idx])\n",
+    "axes[1].set_xlabel(f\"Wavelength [{wavelength.unit}]\")\n",
+    "axes[1].set_ylabel(f\"Radiance [{emission.unit}]\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f5e5a8fc-175e-444a-a827-afdf4aa2f675",
+   "metadata": {},
+   "source": [
+    "The effect has an `update()` method that can be used to change parameter values. The names of the available parameters can be obtained from the list printed above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "099a72d2-09d6-4b0c-8e6f-73a54945adcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky.update(airmass=3., pwv=20.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8b1fddf-ac55-4742-8391-34b1a0799153",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl2 = sky.skycalc_table\n",
+    "\n",
+    "# Extract columns and restrict to a smaller wavelength range\n",
+    "wavelength2 = tbl2['wavelength'].to(u.um)\n",
+    "idx2 = (wavelength2 > 3.4*u.um) * (wavelength2 < 3.6*u.um)\n",
+    "transmission2 = tbl2['transmission']\n",
+    "emission2 = tbl2['emission']\n",
+    "\n",
+    "_, axes = plt.subplots(2, 1, figsize=(8, 8), sharex=True)\n",
+    "axes[0].plot(wavelength[idx], transmission[idx], lw=1)\n",
+    "axes[0].plot(wavelength2[idx2], transmission2[idx2], lw=1)\n",
+    "axes[0].set_ylabel(\"Transmission\")\n",
+    "axes[0].set_xlim(3.4, 3.6)\n",
+    "axes[1].plot(wavelength[idx], emission[idx], lw=1)\n",
+    "axes[1].plot(wavelength2[idx2], emission2[idx2], lw=1)\n",
+    "axes[1].set_xlabel(f\"Wavelength [{wavelength.unit}]\")\n",
+    "axes[1].set_ylabel(f\"Radiance [{emission.unit}]\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9f76808-b785-4201-874c-3a74ff8c2431",
+   "metadata": {},
+   "source": [
+    "## Use in simulations\n",
+    "As an example of how the sky parameters affect observations we simulate METIS N-band images for a number of values of PWV (precipitable water vapour) and record the median background level in the (noiseless) `ImagePlane`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f4c1421-b576-4242-b342-c920e621beb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = sim.UserCommands(use_instrument=\"METIS\", set_modes=[\"img_n\"])\n",
+    "metis = sim.OpticalTrain(cmd)\n",
+    "metis['detector_linearity'].include = False    # to avoid saturation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "547b5167-deb9-4611-b5d5-adfdfa59e160",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky = metis['skycalc_atmosphere']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c736631-1935-4624-b2bc-89e5c1723502",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pwv_values = [0.5, 5, 10, 20]\n",
+    "bg_level = []\n",
+    "plt.figure()\n",
+    "lam = np.linspace(7, 12, 1001) * u.um\n",
+    "for pwv in pwv_values:\n",
+    "    sky.update(pwv=pwv)\n",
+    "    plt.plot(sky.surface.table['wavelength'].to(u.um), sky.surface.table['emission'], label=f\"pwv = {pwv}\", alpha=0.7) \n",
+    "    metis.observe()\n",
+    "    bg_level.append(np.median(metis.image_planes[0].data))\n",
+    "plt.legend();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e03144ee-156d-4150-849d-80889e1b83f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(pwv_values, bg_level, '-o')\n",
+    "plt.ylim(0, 3e8)\n",
+    "plt.xlabel(\"PWV [mm]\")\n",
+    "plt.ylabel(\"ImagePlane level [e/s]\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The notebook shows how to work with `SkycalcTERCurve`, following https://github.com/AstarVienna/ScopeSim/pull/853.
It is placed among the other demo notebooks for METIS for the time being (to keep them in one place), although the effect is more generally used. 