### PR TITLE
Prevent CI from using old ScopeSim version

### DIFF
--- a/requirements.github_actions.txt
+++ b/requirements.github_actions.txt
@@ -5,7 +5,7 @@ astropy[jupyter]
 pyyaml
 paramiko
 astar-utils
-scopesim
+scopesim>=0.11.0
 scopesim_templates
 jupytext
 ipykernel


### PR DESCRIPTION
For some reason it recently started installing v0.7.x, see e.g. https://github.com/AstarVienna/irdb/actions/runs/28363457817/job/84036271153

With this reasonable constraint, it seems to work fine. Not sure what actually caused this, but if there's any version mismatch hidden somewhere, we should now get the actual error message instead of silently installing a 3 yr old version.