### PR TITLE
PSF interpolation parameters

### DIFF
--- a/GTC/GTC.yaml
+++ b/GTC/GTC.yaml
@@ -8,6 +8,7 @@ date_created: 2022-03-02
 date_modified: 2022-03-02
 changes:
   - 2022-02-17 (KL) Created file based on ELT.yaml
+  - 2026-07-07 (OC) Added interpolation parameters for PSF
 
 
 properties:
@@ -54,3 +55,18 @@ effects:
   kwargs:
     filename: PSF_GTC_OSIRIS.fits
     warning: "Default PSF for r-band from GTC website"
+    interp_psf: "!SIM.psf.interp_psf"
+    interp_order: "!SIM.psf.interp_order"
+
+
+---
+### default simulation parameters
+object: simulation
+alias: SIM
+name: GTC_simulation_parameters
+description: RC simulation parameters for GTC simulations
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/METIS/METIS_IMG_LM.yaml
+++ b/METIS/METIS_IMG_LM.yaml
@@ -18,7 +18,7 @@ properties:
   pixel_scale: 0.00547         # arcsec / pixel, METIS_1097
   plate_scale: 0.30389         # arcsec / mm
   filter_file_format: "filters/TC_filter_{}.dat"
-  include_illumination: False     
+  include_illumination: False
 
 effects:
   - name: img_lm_optics
@@ -87,6 +87,8 @@ effects:
       filename_format: "METIS_psfs/PSF_{}.fits"
       wave_key: "WAVELENG"
       bkg_width: -1
+      interp_psf: "!SIM.psf.interp_psf"
+      interp_order: "!SIM.psf.interp_order"
 
   - name: img_lm_fits_keywords
     descriptions: FITS keywords specific to IMG-LM
@@ -99,7 +101,7 @@ effects:
     description: Large-scale illumination variation across the image plane
     class: Illumination
     include: "!INST.include_illumination"
-    
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation
@@ -111,3 +113,6 @@ properties:
   spectral:
     spectral_bin_width: 1.e-3  # microns, defines fov wavelengths
     spectral_resolution: 5000  # defines skycalc resolution
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/METIS/METIS_IMG_N.yaml
+++ b/METIS/METIS_IMG_N.yaml
@@ -80,6 +80,8 @@ effects:
       filename_format: "METIS_psfs/PSF_{}.fits"
       wave_key: "WAVELENG"
       bkg_width: -1
+      interp_psf: "!SIM.psf.interp_psf"
+      interp_order: "!SIM.psf.interp_order"
 
   - name: img_n_fits_keywords
     descriptions: FITS keywords specific to IMG-N
@@ -87,12 +89,12 @@ effects:
     include: True
     kwargs:
       filename: headers/FITS_img_n_keywords.yaml
-  
+
   - name: illumination
     description: Large-scale illumination variation across the image plane
     class: Illumination
     include: "!INST.include_illumination"
-    
+
 ---
 ### default simulation parameters needed for a METIS simulation
 object: simulation
@@ -104,3 +106,6 @@ properties:
   spectral:
     spectral_bin_width: 1.e-3  # microns, defines fov wavelengths
     spectral_resolution: 5000  # defines skycalc resolution
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/METIS/METIS_LMS.yaml
+++ b/METIS/METIS_LMS.yaml
@@ -64,6 +64,8 @@ effects:
       filename_format: "METIS_psfs/PSF_{}.fits"
       wave_key: "WAVELENG"
       bkg_width: -1
+      interp_psf: "!SIM.psf.interp_psf"
+      interp_order: "!SIM.psf.interp_order"
 
   - name: lms_spectral_traces
     description: list of spectral order trace geometry on the focal plane
@@ -94,3 +96,6 @@ properties:
   spectral:
     spectral_bin_width: 1.e-5    # microns, defines fov wavelengths
     spectral_resolution: 200000  # defines skycalc resolution
+  psf:
+    interp_psf: False
+    interp_order: 1

--- a/MICADO/MICADO_Standalone_RO.yaml
+++ b/MICADO/MICADO_Standalone_RO.yaml
@@ -15,6 +15,8 @@ effects :
     kwargs:
         filename : "!RO.psf_file"
         warning : "Default PSF is NOT field varying. See documentation."
+        interp_psf: "!SIM.psf.interp_psf"
+        interp_order: "!SIM.psf.interp_order"
 
 -   name: relay_surface_list
     description : list of surfaces in the relay optics
@@ -47,3 +49,13 @@ name : SCAO
 
 properties :
     ins_mode: "SCAO"
+
+---
+object: simulation
+alias: SIM
+name: simulation_parameters
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/MORFEO/MORFEO.yaml
+++ b/MORFEO/MORFEO.yaml
@@ -22,6 +22,8 @@ effects :
     kwargs:
         filename : "!RO.psf_file"
         warning : "Default PSF is not Field Varying. See Documentation"
+        interp_psf: "!SIM.psf.interp_psf"
+        interp_order: "!SIM.psf.interp_order"
 
 
 ####################### Alternative effects ####################################
@@ -36,3 +38,14 @@ effects :
 #        dit : "!OBS.dit"
 #        ndit : "!OBS.ndit"
 
+---
+### default simulation parameters
+object: simulation
+alias: SIM
+name: MORFEO_simulation_parameters
+description: RC simulation parameters for MORFEO simulations
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/NIRCam/NIRCam_LW.yaml
+++ b/NIRCam/NIRCam_LW.yaml
@@ -60,3 +60,17 @@ effects:
     kwargs:
       filename: "psfs/PSF_NIRCam_in_flight_opd_filter_F322W2.fits"
       wave_key: "WAVELEN"
+      interp_psf: "!SIM.psf.interp_psf"
+      interp_order: "!SIM.psf.interp_order"
+
+---
+### default simulation parameters
+object: simulation
+alias: SIM
+name: NIRCam_simulation_parameters
+description: RC simulation parameters for NIRCam simulations
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/NIRCam/NIRCam_SW.yaml
+++ b/NIRCam/NIRCam_SW.yaml
@@ -55,3 +55,17 @@ effects:
     kwargs:
       filename: "psfs/PSF_NIRCam_in_flight_opd_filter_F150W2.fits"
       wave_key: "WAVELEN"
+      interp_psf: "!SIM.psf.interp_psf"
+      interp_order: "!SIM.psf.interp_order"
+
+---
+### default simulation parameters
+object: simulation
+alias: SIM
+name: NIRCam_simulation_parameters
+description: RC simulation parameters for NIRCam simulations
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1

--- a/VLT/VLT.yaml
+++ b/VLT/VLT.yaml
@@ -19,3 +19,18 @@ effects:
   kwargs:
     filename: PSF_VLT_poppy.fits
     warning: "Default PSF was generated Poppy for a UT4 optical system"
+    interp_psf: "!SIM.psf.interp_psf"
+    interp_order: "!SIM.psf.interp_order"
+
+
+---
+### default simulation parameters
+object: simulation
+alias: SIM
+name: VLT_simulation_parameters
+description: RC simulation parameters for VLT simulations
+
+properties:
+  psf:
+    interp_psf: True
+    interp_order: 1


### PR DESCRIPTION
This PR opens PSF parameters to users via the keywords `!SIM.psf.interp_order` and `!SIM.psf.interp_psf`. The interpolation order is `1` by default (linear interpolation, positive definite) but can be changed to `3` to preserve more contrast in the PSF (at the risk of having negative values in the rescaled PSF).  The value is passed to `scipy.interpolate.RectBivariateSpline`, which thus determines the acceptable values.
`!SIM.psf.interp_psf` replaces `!OBS.interp_psf` to control whether the PSF is scaled to each wavelength slice of a spectral cube. The default is `True` for METIS LSS, and `False` for METIS LMS.