### PR TITLE
Set output formats per mode (MOSAIC)

### DIFF
--- a/MOSAIC/MOSAIC_DET_NIR.yaml
+++ b/MOSAIC/MOSAIC_DET_NIR.yaml
@@ -6,6 +6,8 @@ description: H4RG detector 2.5 um cut-off
 date_modified: 2025-08-07
 changes:
   - 2025-08-07 (OC) adapted from MICADO H4RG
+  - 2026-08-06 (OC) use MosaicOutputFormat
+
 properties:
   detector: HAWAII4RG
   image_plane_id: 0
@@ -92,12 +94,12 @@ effects:
       dtype: float32
       gain: "!DET.gain"
 
-  - name: collapse_1d
-    description: Collapse fiber bundle to 1D spectrum
-    class: MosaicCollapseSpectralTraces
-    include:  "!OBS.do_collapse_1d"
+  - name: output_format
+    description: Reformat MOS/mIFU output
+    class: MosaicOutputFormat
     kwargs:
       filename: "!OBS.trace_file"
+      format: "!OBS.output_format"
 
 #  - name: det_nir_fits_keywords
 #    description: FITS keywords specific to NIR detector

--- a/MOSAIC/MOSAIC_DET_VIS.yaml
+++ b/MOSAIC/MOSAIC_DET_VIS.yaml
@@ -4,7 +4,7 @@ object: detector
 alias: DET
 name: MOSAIC_DET_VIS
 description: virtual detector for one fiber bundle
-data_modified: 2025-10-24
+data_modified: 2026-08-06
 
 
 properties:
@@ -64,8 +64,9 @@ effects:
       dtype: float32
       gain: "!DET.gain"
 
-  - name: collapse_1d
-    description: Collapse fiber bundle to 1D spectrum
-    class: MosaicCollapseSpectralTraces
+  - name: output_format
+    description: Reformat MOS/mIFU output
+    class: MosaicOutputFormat
     kwargs:
       filename: "!OBS.trace_file"
+      format: "!OBS.output_format"

--- a/MOSAIC/default.yaml
+++ b/MOSAIC/default.yaml
@@ -5,9 +5,10 @@ alias : OBS
 name : MOSAIC_default_configuration
 description : default parameters needed for a MOSAIC simulation
 needs_scopesim: "v0.11.0"
-date_modified: 2025-09-01
+date_modified: 2026-08-06
 changes:
   - 2025-09-01 (OC) adjusted resolutions for modes
+  - 2026-08-06 (OC) set output format per mode
 
 packages :
   - Armazones
@@ -31,8 +32,7 @@ properties :
   ra : 0.0
   dec : 0.0
   psf_fwhm : 0.2
-  include_fibres : True
-  do_collapse_1d: True
+  output_format: collapse1d
 
 mode_yamls :
   - object: observation
@@ -50,6 +50,7 @@ mode_yamls :
       trace_file: TRACE_MOS-LR-B.fits
       dispersion: 1.9e-5      # um/pixel on the output detector
       resolution: 32000       # resolution of sky spectrum
+      output_format: collapse1d
 
   - object: observation
     alias: OBS
@@ -65,6 +66,7 @@ mode_yamls :
       trace_file: TRACE_MOS-HR-B1.fits
       dispersion: 6.5e-6    # um/pixel on detector
       resolution: 72000     # resolution of sky spectrum
+      output_format: collapse1d
 
   - object: observation
     alias: OBS
@@ -80,6 +82,7 @@ mode_yamls :
       trace_file: TRACE_MOS-HR-B2.fits
       dispersion: 5e-6    # um/pixel on detector
       resolution: 72000     # resolution of sky spectrum
+      output_format: collapse1d
 
   - object: observation
     alias: OBS
@@ -96,6 +99,7 @@ mode_yamls :
       trace_file: TRACE_MOS-LR-R.fits
       dispersion: 3e-5      # um/pixel on the output detector
       resolution: 32000       # resolution of sky spectrum
+      output_format: collapse1d
 
   - object: observation
     alias: OBS
@@ -111,6 +115,7 @@ mode_yamls :
       trace_file: TRACE_MOS-HR-R1.fits
       dispersion: 8e-6    # um/pixel on detector
       resolution: 72000       # resolution of sky spectrum
+      output_format: collapse1d
 
   - object: observation
     alias: OBS
@@ -126,6 +131,7 @@ mode_yamls :
       trace_file: TRACE_MOS-HR-R2.fits
       dispersion: 1e-5    # um/pixel on detector
       resolution: 72000       # resolution of sky spectrum
+      output_format: collapse1d
 
   - object : instrument
     alias: OBS
@@ -142,6 +148,7 @@ mode_yamls :
       trace_file: TRACE_MOS-LR-J.fits
       dispersion: 9.5e-5    # um/pixel on detector
       resolution: 16000     # resolution of sky spectrum
+      output_format: collapse1d
 
   - object : instrument
     alias: OBS
@@ -158,6 +165,7 @@ mode_yamls :
       trace_file: TRACE_MOS-LR-H.fits
       dispersion: 9.e-5     # um/pixel on detector
       resolution: 16000     # resolution of sky spectrum
+      output_format: collapse1d
 
   - object : instrument
     alias: OBS
@@ -174,6 +182,7 @@ mode_yamls :
       trace_file: TRACE_MOS-HR-H.fits
       dispersion: 2.4e-5    # um/pixel on detector
       resolution: 72000     # resolution of sky spectrum
+      output_format: collapse1d
 
   - object : instrument
     alias: OBS
@@ -190,7 +199,7 @@ mode_yamls :
       trace_file: TRACE_mIFU-LR-J.fits
       dispersion: 9.5e-5    # um/pixel on detector
       resolution: 16000     # resolution of sky spectrum
-      do_collapse_1d: False
+      output_format: table
 
   - object : instrument
     alias: OBS
@@ -207,7 +216,7 @@ mode_yamls :
       trace_file: TRACE_mIFU-LR-H.fits
       dispersion: 9.e-5     # um/pixel on detector
       resolution: 16000     # resolution of sky spectrum
-      do_collapse_1d: False
+      output_format: table
 
   - object : instrument
     alias: OBS
@@ -224,8 +233,7 @@ mode_yamls :
       trace_file: TRACE_mIFU_NIR-HR-H.fits
       dispersion: 2.4e-5    # um/pixel on detector
       resolution: 72000     # resolution of sky spectrum
-      do_collapse_1d: False
-
+      output_format: table
 
 
 ---

--- a/MOSAIC/docs/example_notebooks/MOSAIC_demo.ipynb
+++ b/MOSAIC/docs/example_notebooks/MOSAIC_demo.ipynb
@@ -5,8 +5,6 @@
    "id": "612ecdf2-d7da-4a1f-87da-ff42d5a7e222",
    "metadata": {},
    "source": [
-    "# MOSAIC Demo\n",
-    "\n",
     "This is a simple demo of the \"ETC\" mode for MOSAIC. To use this you need the `oc/mosaic` branch of Scopesim and the `oc/mosaic` branch of the irdb. The implementation creates one-dimensional spectra for the output (summed over the fibres in a bundle for the MOS modes). The first sections demonstrate how to use Scopesim for the MOS and mIFU modes. The final section provides a more detailed description of the implementation and instrument definition that is currently used."
    ]
   },
@@ -114,7 +112,7 @@
     "- The visual modes map spectra to a pseudo-detector of length 13000 pixels; the gap between the two 6k detectors in the real instrument is not simulated.\n",
     "- The near-infrared modes map spectra to a 4k x 4k detector.\n",
     "- As stated above, the MOS modes collapse the 7 (low-res modes) or 19 (high-res modes) fibres in a bundle to a single one-dimensional spectrum, the output is a FITS binary table with wavelength and flux (in ADU).\n",
-    "- The mIFU modes return a 4k x 4k image with each of the 4xx fibre spectra mapped onto a detector row each. Rearrangement of the spectra into a cube has not been implemented."
+    "- The mIFU modes return a FITS binary table with one row per fiber, with wavelength and flux vectors as well as the on-sky position of the fiber relative to the centre of the bundle."
    ]
   },
   {
@@ -233,7 +231,7 @@
    "id": "6870b5cb-da6f-48ab-b841-d1b60400c79c",
    "metadata": {},
    "source": [
-    "The actual detector \"image\" including dark current, shot noise and readout noise is created in the next step, where we have to specify the exposure time."
+    "The actual detector readout including dark current, shot noise and readout noise is created in the next step, where we have to specify the exposure time."
    ]
   },
   {
@@ -619,7 +617,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mosaic.observe()"
+    "mosaic.observe(gal)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0a72d51-ef19-4e0e-b958-01d660fa1565",
+   "metadata": {},
+   "source": [
+    "The arrangement of the spectra on the pseudo-detector can be shown by displaying the `ImagePlane`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d4d3e953-795f-4c24-99d6-d5aa549a6bf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(mosaic.image_planes[0].data[900:1100, 1900:2100], norm='log', origin='lower')\n",
+    "plt.colorbar();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b020e606-dfa0-47d6-b21e-c55a88f4a106",
+   "metadata": {},
+   "source": [
+    "`readout` applies the exposure time and adds shot noise and detector noises. Finally, it converts the output to a fits binary table."
    ]
   },
   {
@@ -635,12 +660,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4d3e953-795f-4c24-99d6-d5aa549a6bf2",
+   "id": "97cf4e05-0247-4db4-a93c-9da9373a3ad8",
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.imshow(hdul[1].data[900:1100, 1900:2100], norm='log', origin='lower')\n",
-    "plt.colorbar();"
+    "hdul[1].data.names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "46d4a767-2bfc-466d-8369-545ce131d459",
+   "metadata": {},
+   "source": [
+    "The class of `hdul[1].data` is `FITS_rec`. Converting it to an actual table makes it easier to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eeb6d0e9-73a8-47fa-8302-c9931cedf3f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astropy.table import Table\n",
+    "fiber_table = Table(hdul[1].data)\n",
+    "print(fiber_table[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cbd0ef7a-863b-457f-8995-b940818f96ca",
+   "metadata": {},
+   "source": [
+    "The arrangement of the fibres in the bundle (or rather on sky) can be visualised by plotting the `x` and `y` columns. Colour-coding the points by the sum over the respective spectrum provides a crude image reconstruction."
    ]
   },
   {
@@ -650,15 +702,46 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(hdul[1].data[991, :])"
+    "total_flux = np.zeros(len(fiber_table))\n",
+    "for i, spec in enumerate(fiber_table['spectrum']):\n",
+    "    total_flux[i] = spec.sum()\n",
+    "\n",
+    "plt.scatter(fiber_table['x'], fiber_table['y'], marker='o', c=np.log(total_flux), cmap=plt.cm.hot)\n",
+    "plt.gca().set_aspect('equal')\n",
+    "plt.colorbar()\n",
+    "plt.xlabel(\"x [arcsec]\")\n",
+    "plt.ylabel(\"y [arcsec]\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f25addbb-0578-4ced-964d-f0560a41a963",
+   "id": "a7c651ad-aefa-4e2d-8b90-c92a9afe3fc4",
    "metadata": {},
    "source": [
-    "The mIFU mode is incomplete - it is currently not possible to deduce the wavelength vector and the spatial arrangement of the fibres from the readout alone. A table format might be better suited for that purpose."
+    "The fiber ids follow the pattern `FIBER_<num>`. To show the spectrum of an individual fiber one could select the corresponding row as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0636371b-7848-4e05-8873-536264bad5dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fiber_11 = fiber_table[fiber_table['id'] == \"FIBER_11\"][0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08b34451-52c6-4acb-8cc6-09d7fdc6499b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.plot(fiber_11['wavelength'], fiber_11['spectrum'])\n",
+    "plt.xlabel(\"wavelength [um]\")\n",
+    "plt.ylabel(\"flux [ADU]\")\n",
+    "plt.title(fiber_11['id']);"
    ]
   },
   {
@@ -699,7 +782,7 @@
     "\n",
     "<img src=\"static/MOSAIC-QE.png\" style=\"width:400px\"> </img>\n",
     "\n",
-    "Finally, both detector yamls include the effect `collapse_1d`, which sums up the separate spectra from the fibres and produces a single output spectrum as described above. It is possible to switch this off with `mosaic['collapse_1d'].include=False` to see the \"detector image\". However, due to the way the spectra are currently formed, this is probably not of much interest."
+    "Finally, both detector yamls include the effect `output_format` with the parameter `format=\"collapse1d\"` for the MOS modes and `format=\"table\"` for the mIFU modes. This effect converts the detector image to a table format. In the case of the MOS modes, the spectra from all fibers are summed up to produce a single output spectrum as described above, in the case of mIFU, the spectra are arranged in a binary table including the spatial information."
    ]
   }
  ],
@@ -719,7 +802,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.5"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Use the `MosaicOutputFormat` effect (https://github.com/AstarVienna/ScopeSim/pull/968) to set the default output modes to `collapse1d` for the MOS modes and `table` for the mIFU modes.
The example notebook has been updated and includes a crude image reconstruction from an mIFU simulation of a galaxy:
<img width="612" height="449" alt="mosaic_mIFU_reconstruction" src="https://github.com/user-attachments/assets/40d86e39-f770-44e9-9da6-570ce8cef927" />

Cf. #288 