### PR TITLE
Fix notebook to account for Scopesim #962

### DIFF
--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -513,7 +513,7 @@
     "print(f\"Open: {flux_is:.1f}\")\n",
     "print(f\"Mask: {flux_pin:.1f}\")\n",
     "\n",
-    "assert np.allclose(flux_is/flux_pin, wcu.meta['rho_is']/wcu.meta['emiss_mask'], rtol=0.01)"
+    "assert np.allclose(flux_is/flux_pin, 1./wcu.meta['emiss_mask'], rtol=0.01)"
    ]
   }
  ],


### PR DESCRIPTION
AstarVienna/ScopeSim/pull/962 changed the emission of the integrating sphere in the METIS WCU. This change had not been taken into account in `METIS_WCU.ipynb` causing an assert in the last cell to fail. This PR fixes that.