### PR TITLE
Move laser parameters to config yaml

### DIFF
--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -490,7 +490,7 @@
    "source": [
     "## Changing wavelengths of the tunable laser\n",
     "The wavelengths of the tunable laser as set in the configuration file are chosen to represent a scenario where the laser changes rapidly between 10 wavelengths so that 10 lines appear in a single exposure. In this scenario, the laser's power is distributed equally onto these 10 lines. In practice it might be preferable to have the laser at a single wavelength setting during the exposure. \n",
-    "The wavelength can be changed by setting the keyword `wcu.meta[\"laser_t_wave\"]` to the desired value or array of values. To make the change effective, the statement needs to be followed by `metis.set_lamp(\"laser\")`, as this command triggers the computation of the laser spectrum. "
+    "The wavelength can be changed with the utility function `wcu.tune_laser(wavelength=...)`, where the argument is either a number or a list of wavelengths (units are assumed to be micrometers)."
    ]
   },
   {
@@ -538,11 +538,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Change the wavelenght of the tunable laser\n",
-    "wcu.meta['laser_t_wave'] = [4.85]\n",
-    "# Make the change effective by setting the lamp to \"laser\" again \n",
-    "wcu.set_lamp(\"laser\")\n",
-    "\n",
+    "# Change the wavelength of the tunable laser\n",
+    "wcu.tune_laser(wavelength=4.85)\n",
     "metis.observe()\n",
     "implane_single = metis.image_planes[0].data"
    ]

--- a/METIS/docs/example_notebooks/METIS_WCU.ipynb
+++ b/METIS/docs/example_notebooks/METIS_WCU.ipynb
@@ -446,6 +446,21 @@
     "fpmask_angle: 0\n",
     "fpmask_shift: [0, 0]\n",
     "\n",
+    "# ------------- Available lasers\n",
+    "## L-band\n",
+    "laser_l_wave: 3.39    # [um]\n",
+    "laser_l_power: 5e-3   # [W]\n",
+    "## tunable QCL\n",
+    "laser_t_wave: [4.68, 4.69, 4.70, 4.71, 4.72, 4.73, 4.74, 4.75, 4.76, 4.77]  # [um], array\n",
+    "laser_t_wave_limits: [1., 30.]  # um, for validation\n",
+    "laser_t_power: 70e-3  # [W], will be divided by number of lines\n",
+    "## M-band\n",
+    "laser_m_wave: 5.26    # [um]\n",
+    "laser_m_power: 20e-3  # [W]\n",
+    "## N-band (for AIT only)\n",
+    "laser_n_wave: [8.0, 9.0, 10.4, 11.5, 12.4]  # [um], array\n",
+    "laser_n_power: [2.e-3, 1.4e-3, 2.e-3, 0.8e-3, 0.5e-3]  # [W], for each laser\n",
+    "\n",
     "# ------------- Data needed to describe the WCU\n",
     "bb_to_is:     \"wcu/WCU_BB_to_IS_throughput.fits\"\n",
     "is_reflect:   \"wcu/WCU_IS_reflectivity.dat\"\n",
@@ -458,6 +473,7 @@
     "rho_is:        0.95     # [] reflectivity of integrating sphere\n",
     "rho_tube:      0.95     # [] reflectivity of tube between BB and IS\n",
     "emiss_mask:    1.00     # [] emissivity of focal-plane mask\n",
+    "fibre_transmission: 0.1 # [] transmission of fibres injecting laser into IS\n",
     "```\n",
     "To use your own configuration file, copy the default file into your working directory and instantiate the `OpticalTrain` as follows:\n",
     "```python\n",
@@ -465,6 +481,90 @@
     "cmd[\"!WCU.config_file\") = \"my_config.yaml\"\n",
     "metis = sim.OpticalTrain(cmd)\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "13ea5a99-e937-436e-8553-cfeab7c069fb",
+   "metadata": {},
+   "source": [
+    "## Changing wavelengths of the tunable laser\n",
+    "The wavelengths of the tunable laser as set in the configuration file are chosen to represent a scenario where the laser changes rapidly between 10 wavelengths so that 10 lines appear in a single exposure. In this scenario, the laser's power is distributed equally onto these 10 lines. In practice it might be preferable to have the laser at a single wavelength setting during the exposure. \n",
+    "The wavelength can be changed by setting the keyword `wcu.meta[\"laser_t_wave\"]` to the desired value or array of values. To make the change effective, the statement needs to be followed by `metis.set_lamp(\"laser\")`, as this command triggers the computation of the laser spectrum. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f8534a3e-d4dd-4eac-a1f1-52ab38c250e5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = sim.UserCommands(use_instrument='METIS', set_modes=['wcu_lss_m'])\n",
+    "metis = sim.OpticalTrain(cmd)\n",
+    "wcu = metis['wcu_source']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d130f6bf-eae3-4498-89c0-9ed1e113a49b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Take a background frame (WCU_OFF)\n",
+    "wcu.set_lamp(\"off\")\n",
+    "metis.observe()\n",
+    "implane_off = metis.image_planes[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac6d3cd1-e8b1-4fa6-b1e5-08a33c4d14a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Take exposure with default laser setting\n",
+    "wcu.set_lamp(\"laser\")\n",
+    "metis.observe()\n",
+    "implane_default = metis.image_planes[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ac767bb1-e6f5-4612-94c7-6ae763d6f9c7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Change the wavelenght of the tunable laser\n",
+    "wcu.meta['laser_t_wave'] = [4.85]\n",
+    "# Make the change effective by setting the lamp to \"laser\" again \n",
+    "wcu.set_lamp(\"laser\")\n",
+    "\n",
+    "metis.observe()\n",
+    "implane_single = metis.image_planes[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3f6d12e-5824-4bd7-83fb-ca866545707c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axes = plt.subplots(1, 2, sharey=True)\n",
+    "axes[0].imshow(implane_default - implane_off, origin='lower', vmin=0, vmax=2e5)\n",
+    "axes[1].imshow(implane_single - implane_off, origin='lower', vmin=0, vmax=2e5);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f97289c9-58e2-435b-98c8-ff2d2307abfa",
+   "metadata": {},
+   "source": [
+    "Note that the single line is 10 times as bright as the individual lines in the default setting."
    ]
   },
   {

--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -15,6 +15,7 @@ fpmask_shift: [0, 0]
 laser_l_wave: 3.39    # [um]
 laser_l_power: 5e-3   # [W]
 laser_t_wave: [4.68, 4.69, 4.70, 4.71, 4.72, 4.73, 4.74, 4.75, 4.76, 4.77]  # [um], array
+laser_t_wave_limits: [1., 30.]  # um, for validation
 laser_t_power: 70e-3  # [W], will be divided by number of lines
 laser_m_wave: 5.26    # [um]
 laser_m_power: 20e-3  # [W]

--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -11,6 +11,15 @@ current_fpmask: "open"
 fpmask_angle: 0
 fpmask_shift: [0, 0]
 
+# ------------- Available lasers
+laser_l_wave: 3.39    # [um]
+laser_l_power: 5e-3   # [W]
+laser_t_wave: [4.70]  # [um], array
+laser_t_power: 70e-3  # [W], will be divided by number of lines
+laser_m_wave: 5.26    # [um]
+laser_m_power: 20e-3  # [W]
+
+
 # ------------- Data needed to describe the WCU
 bb_to_is:     "wcu/WCU_BB_to_IS_throughput.fits"
 is_reflect:   "wcu/WCU_IS_reflectivity.dat"

--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -14,11 +14,16 @@ fpmask_shift: [0, 0]
 # ------------- Available lasers
 laser_l_wave: 3.39    # [um]
 laser_l_power: 5e-3   # [W]
+
 laser_t_wave: [4.68, 4.69, 4.70, 4.71, 4.72, 4.73, 4.74, 4.75, 4.76, 4.77]  # [um], array
 laser_t_wave_limits: [1., 30.]  # um, for validation
 laser_t_power: 70e-3  # [W], will be divided by number of lines
+
 laser_m_wave: 5.26    # [um]
 laser_m_power: 20e-3  # [W]
+
+laser_n_wave: [8.0, 9.0, 10.4, 11.5, 12.4]  # [um], array
+laser_n_power: [2.e-3, 1.4e-3, 2.e-3, 0.8e-3, 0.5e-3]  # [W], for each laser
 
 
 # ------------- Data needed to describe the WCU

--- a/METIS/metis_wcu_config.yaml
+++ b/METIS/metis_wcu_config.yaml
@@ -14,7 +14,7 @@ fpmask_shift: [0, 0]
 # ------------- Available lasers
 laser_l_wave: 3.39    # [um]
 laser_l_power: 5e-3   # [W]
-laser_t_wave: [4.70]  # [um], array
+laser_t_wave: [4.68, 4.69, 4.70, 4.71, 4.72, 4.73, 4.74, 4.75, 4.76, 4.77]  # [um], array
 laser_t_power: 70e-3  # [W], will be divided by number of lines
 laser_m_wave: 5.26    # [um]
 laser_m_power: 20e-3  # [W]


### PR DESCRIPTION
- Laser wavelengths and powers are now in `metis_wcu_config.yaml` instead of hard-coded in ScopeSim.  
- N-band lasers have been added with wavelengths 8.0, 9.0, 10.4, 11.5, 12.4 um and powers of 2.0, 1.4, 2.0, 0.8, 0.5 mW, respectively. All N-band lasers are on at the same time. 
- A section has been added to `METIS_WCU.ipynb` to explain how to change the settings of the tunable laser. 